### PR TITLE
WhiteList -> PaymentGateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
 * homebrewがインストールされている
 
 
-
 ### 1.1. Python3.6の実行環境を整備する
 * (参考：https://develtips.com/python/191)
 
+
 ### 1.2. geth をインストールする。
 * (参考：https://qiita.com/tmrex7/items/912ec05eff02f7f76d30)
+
 
 ### 1.3. solidity compiler (solc) をインストールする。
 * brew install すると0.5系が入ってしまう。
@@ -42,10 +43,12 @@ solc, the solidity compiler commandline interface
 Version: 0.4.25+commit.59dbf8f1.Darwin.appleclang
 ```
 
+
 ### 1.4. tmr-scをgit cloneする。
 ```
 $ git clone https://github.com/N-Village/tmr-sc.git
 ```
+
 
 ### 1.5. Pyenv (virtualenv)の環境を作る
 * （参考：https://qiita.com/its/items/24f8b20aa2106819dfb3）
@@ -72,6 +75,7 @@ $ pyenv versions
   3.6.4/envs/tmr-sc
 * tmr-sc (set by /Users/*/tmr-sc/.python-version)
 ```
+
 
 ### 1.6. 依存パッケージのインストール
 * 依存パッケージをpipでインストールする。
@@ -106,7 +110,6 @@ Commands:
 
 
 
-
 ### 1.7. AWS CLIの導入ならびにECRにログイン
 * ibet 開発AWSのECRのイメージを使うので、AWS CLIの導入ならびにECRにログインしておく
 * ※事前にAWS Access Key IDとAWS Secret Access Key等の情報を入手しておく
@@ -134,7 +137,7 @@ https://aws_account_id.dkr.ecr.us-east-1.amazonaws.com
 
 
 
-### 1.8. dockerを入れる
+### 1.8. dockerインストール
 * 公式サイトから Docker for Macをダウンロードしてインストールする(https://docs.docker.com/docker-for-mac/install/) 
 * 正しくインストールされているか確認する
 
@@ -199,34 +202,11 @@ Welcome to the Geth JavaScript console!
 ```
 
 
-
 ## 2. コントラクトコードのコンパイル
 * コントラクトコード（Solidityコード）自体は、好きなエディタで実装して良い。
 * 出来上がったコントラクトコードを `contracts/` ディレクトリ以下に格納していく。
 * コードのコンパイルは以下のコマンドを実行する。
 * 実行結果（abi, bytecode, bytecode_runtime など）は `build/contracts.json` に保存される。
-
-```
-$ populus compile
-> Found 7 contract source files
-  - contracts/IbetStraightBond.sol
-  - contracts/IbetStraightBondExchange.sol
-  - contracts/Ownable.sol
-  - contracts/PersonalInfo.sol
-  - contracts/SafeMath.sol
-  - contracts/TokenList.sol
-  - contracts/WhiteList.sol
-> Compiled 8 contracts
-  - contracts/IbetStraightBond.sol:ContractReceiver
-  - contracts/IbetStraightBond.sol:IbetStraightBond
-  - contracts/IbetStraightBondExchange.sol:IbetStraightBondExchange
-  - contracts/Ownable.sol:Ownable
-  - contracts/PersonalInfo.sol:PersonalInfo
-  - contracts/SafeMath.sol:SafeMath
-  - contracts/TokenList.sol:TokenList
-  - contracts/WhiteList.sol:WhiteList
-> Wrote compiled assets to: build/contracts.json
-```
 
 ## 3. テスト
 * テスト実行はpytestで実行する。

--- a/deploy/contract_deploy.py
+++ b/deploy/contract_deploy.py
@@ -7,21 +7,41 @@ project = Project()
 with project.get_chain('dev_chain') as chain:
     web3 = chain.web3
     web3.eth.defaultAccount = web3.eth.accounts[0]
-    web3.personal.unlockAccount(web3.eth.defaultAccount, os.environ.get('ETH_ACCOUNT_PASSWORD'), 0)
+    web3.personal.unlockAccount(web3.eth.defaultAccount, os.environ.get('ETH_ACCOUNT_PASSWORD'), 1000)
 
+    # TokenList
     token_list, _ = chain.provider.get_or_deploy_contract('TokenList')
+
+    # PersonalInfo
     personal_info, _ = chain.provider.get_or_deploy_contract('PersonalInfo')
-    white_list, _ = chain.provider.get_or_deploy_contract('WhiteList')
-    deploy_args = [white_list.address, personal_info.address]
+
+    # PaymentGateway
+    payment_gateway, _ = chain.provider.get_or_deploy_contract('PaymentGateway')
+
+    # IbetStraightBondExchange
+    deploy_args = [payment_gateway.address, personal_info.address]
     bond_exchange, _ = chain.provider.get_or_deploy_contract(
         'IbetStraightBondExchange',
         deploy_args = deploy_args
     )
-    coupon_exchange, _ = chain.provider.get_or_deploy_contract('IbetCouponExchange')
-    membership_exchange, _ = chain.provider.get_or_deploy_contract('IbetMembershipExchange')
+
+    # IbetCouponExchange
+    deploy_args = [payment_gateway.address]
+    coupon_exchange, _ = chain.provider.get_or_deploy_contract(
+        'IbetCouponExchange',
+        deploy_args = deploy_args
+    )
+
+    # IbetMembershipExchange
+    deploy_args = [payment_gateway.address]
+    membership_exchange, _ = chain.provider.get_or_deploy_contract(
+        'IbetMembershipExchange',
+        deploy_args = deploy_args
+    )
+
     print('TokenList : ' + token_list.address)
     print('PersonalInfo : ' + personal_info.address)
-    print('WhiteList : ' + white_list.address)
+    print('PaymentGateway : ' + payment_gateway.address)
     print('IbetStraightBondExchange : ' + bond_exchange.address)
     print('IbetCouponExchange : ' + coupon_exchange.address)
     print('IbetMembershipExchange : ' + membership_exchange.address)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,15 +36,17 @@ def personal_info(web3, chain, users):
     return personal_info
 
 @pytest.yield_fixture()
-def white_list(web3, chain, users):
+def payment_gateway(web3, chain, users):
     web3.eth.defaultAccount = users['admin']
-    white_list, _ = chain.provider.get_or_deploy_contract('WhiteList')
-    return white_list
+    payment_gateway, _ = chain.provider.get_or_deploy_contract('PaymentGateway')
+    txn_hash = payment_gateway.transact().addAgent(0, users['agent'])
+    chain.wait.for_receipt(txn_hash)
+    return payment_gateway
 
 @pytest.yield_fixture()
-def bond_exchange(web3, chain, users, personal_info, white_list):
+def bond_exchange(web3, chain, users, personal_info, payment_gateway):
     web3.eth.defaultAccount = users['admin']
-    deploy_args = [white_list.address, personal_info.address]
+    deploy_args = [payment_gateway.address, personal_info.address]
     bond_exchange, _ = chain.provider.get_or_deploy_contract(
         'IbetStraightBondExchange',
         deploy_args = deploy_args
@@ -52,9 +54,9 @@ def bond_exchange(web3, chain, users, personal_info, white_list):
     return bond_exchange
 
 @pytest.yield_fixture()
-def membership_exchange(web3, chain, users):
+def membership_exchange(web3, chain, users, payment_gateway):
     web3.eth.defaultAccount = users['admin']
-    deploy_args = []
+    deploy_args = [payment_gateway.address]
     membership_exchange, _ = chain.provider.get_or_deploy_contract(
         'IbetMembershipExchange',
         deploy_args = deploy_args
@@ -62,9 +64,9 @@ def membership_exchange(web3, chain, users):
     return membership_exchange
 
 @pytest.yield_fixture()
-def coupon_exchange(web3, chain, users):
+def coupon_exchange(web3, chain, users, payment_gateway):
     web3.eth.defaultAccount = users['admin']
-    deploy_args = []
+    deploy_args = [payment_gateway.address]
     coupon_exchange, _ = chain.provider.get_or_deploy_contract(
         'IbetCouponExchange',
         deploy_args = deploy_args


### PR DESCRIPTION
close #78 

新規注文時に指定する収納代行アドレス（Agent）の偽装防止。

### 修正１：WhiteList → PaymentGateway
・収納代行業者（Agent）の情報をibetネットワーク内で中央集権的にリスティングするように設計修正。
・ネットワーク管理者（開発コミュニティ）のみリストの修正が可能とした。

・リスティングを旧WhiteList内で行うように修正。
・WhiteListはもともと振込用銀行口座の認可情報のみを保持していたが、収納代行業者の機能を多く持つようになってきたため、コントラクト機能の位置付けを変更。収納代行機能をまとめて提供するコントラクトとする。
・コントラクトの名称も「WhiteList」から「PaymentGateway」に変更。
・同時にコントラクト内のFunction名も微修正。

### 修正２：DEX createOrder
・各種商品トークンのDEXでの新規注文時（createOrder）に、Agentアドレスのチェックを追加。
　ネットワークで認可されたAgentアドレスであることをチェック。
・テストケースを修正。

### 修正３：その他
・コントラクトのデプロイスクリプトを修正。
