### PR TITLE
eternal storage の導入

### DIFF
--- a/contracts/ContractReceiver.sol
+++ b/contracts/ContractReceiver.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.4.24;
 
 contract ContractReceiver {
-  function tokenFallback(address _from, uint _value, bytes _data) public;
+  function tokenFallback(address _from, uint _value, bytes memory _data) public;
 }

--- a/contracts/ExchangeStorage.sol
+++ b/contracts/ExchangeStorage.sol
@@ -1,0 +1,438 @@
+pragma solidity ^0.4.24;
+
+import "./Ownable.sol";
+
+// =========================================================================
+// ExchangeStorage
+//   Exchange コントラクトの取引情報を管理するための Eternal Storage
+// =========================================================================
+contract ExchangeStorage is Ownable {
+
+    constructor() public {}
+
+    // -------------------------------------------------------------------
+    // 最新バージョンのExchangeコントラクトアドレス
+    // -------------------------------------------------------------------
+    address public latestVersion;
+
+    function upgradeVersion(address _newVersion)
+        public
+        onlyOwner()
+    {
+        latestVersion = _newVersion;
+    }
+
+    modifier onlyLatestVersion() {
+       require(msg.sender == latestVersion);
+        _;
+    }
+
+    // -------------------------------------------------------------------
+    // 残高数量
+    // -------------------------------------------------------------------
+
+    // +++++++++++++++++++
+    // 残高情報
+    // account => token => balance
+    // +++++++++++++++++++
+    mapping(address => mapping(address => uint256)) public balances;
+
+    function setBalance(address _account, address _token, uint256 _value)
+        public
+        returns (bool)
+    {
+        balances[_account][_token] = _value;
+    }
+
+    function getBalance(address _account, address _token)
+        public
+        view
+        returns (uint256)
+    {
+        return balances[_account][_token];
+    }
+
+    // -------------------------------------------------------------------
+    // 拘束数量
+    // -------------------------------------------------------------------
+
+    // +++++++++++++++++++
+    // 拘束数量
+    // account => token => order commitment
+    // +++++++++++++++++++
+    mapping(address => mapping(address => uint256)) public commitments;
+
+    function setCommitment(address _account, address _token, uint256 _value)
+        public
+        onlyLatestVersion()
+    {
+        commitments[_account][_token] = _value;
+    }
+
+    function getCommitment(address _account, address _token)
+        public
+        view
+        returns (uint256)
+    {
+        return commitments[_account][_token];
+    }
+
+    // -------------------------------------------------------------------
+    // 注文情報
+    // -------------------------------------------------------------------
+    struct Order {
+        address owner;
+        address token;
+        uint256 amount; // 数量
+        uint256 price; // 価格
+        bool isBuy; // 売買区分（買い：True）
+        address agent; // 決済業者のアドレス
+        bool canceled; // キャンセル済みフラグ
+    }
+
+    // +++++++++++++++++++
+    // 注文情報
+    // orderId => order
+    // +++++++++++++++++++
+    mapping(uint256 => Order) public orderBook;
+
+    function setOrder(
+        uint256 _orderId, address _owner, address _token,
+        uint256 _amount, uint256 _price, bool _isBuy,
+        address _agent, bool _canceled)
+        public
+        onlyLatestVersion()
+    {
+        orderBook[_orderId].owner = _owner;
+        orderBook[_orderId].token = _token;
+        orderBook[_orderId].amount = _amount;
+        orderBook[_orderId].price = _price;
+        orderBook[_orderId].isBuy = _isBuy;
+        orderBook[_orderId].agent = _agent;
+        orderBook[_orderId].canceled = _canceled;
+    }
+
+    function setOrderOwner(uint256 _orderId, address _owner)
+        public
+        onlyLatestVersion()
+    {
+        orderBook[_orderId].owner = _owner;
+    }
+
+    function setOrderToken(uint256 _orderId, address _token)
+        public
+        onlyLatestVersion()
+    {
+        orderBook[_orderId].token = _token;
+    }
+
+    function setOrderAmount(uint256 _orderId, uint256 _amount)
+        public
+        onlyLatestVersion()
+    {
+        orderBook[_orderId].amount = _amount;
+    }
+
+    function setOrderPrice(uint256 _orderId, uint256 _price)
+        public
+        onlyLatestVersion()
+    {
+        orderBook[_orderId].price = _price;
+    }
+
+    function setOrderIsBuy(uint256 _orderId, bool _isBuy)
+        public
+        onlyLatestVersion()
+    {
+        orderBook[_orderId].isBuy = _isBuy;
+    }
+
+    function setOrderAgent(uint256 _orderId, address _agent)
+        public
+        onlyLatestVersion()
+    {
+        orderBook[_orderId].agent = _agent;
+    }
+
+    function setOrderCanceled(uint256 _orderId, bool _canceled)
+        public
+        onlyLatestVersion()
+    {
+        orderBook[_orderId].canceled = _canceled;
+    }
+
+    function getOrder(uint256 _orderId)
+        public
+        view
+        returns(address owner, address token, uint256 amount, uint256 price,
+        bool isBuy, address agent, bool canceled)
+    {
+        return (
+            orderBook[_orderId].owner,
+            orderBook[_orderId].token,
+            orderBook[_orderId].amount,
+            orderBook[_orderId].price,
+            orderBook[_orderId].isBuy,
+            orderBook[_orderId].agent,
+            orderBook[_orderId].canceled
+        );
+    }
+
+
+    function getOrderOwner(uint256 _orderId)
+        public
+        view
+        returns(address)
+    {
+        return orderBook[_orderId].owner;
+    }
+
+    function getOrderToken(uint256 _orderId)
+        public
+        view
+        returns(address)
+    {
+        return orderBook[_orderId].token;
+    }
+
+    function getOrderAmount(uint256 _orderId)
+        public
+        view
+        returns(uint256)
+    {
+        return orderBook[_orderId].amount;
+    }
+
+    function getOrderPrice(uint256 _orderId)
+        public
+        view
+        returns(uint256)
+    {
+        return orderBook[_orderId].price;
+    }
+
+    function getOrderIsBuy(uint256 _orderId)
+        public
+        view
+        returns(bool)
+    {
+        return orderBook[_orderId].isBuy;
+    }
+
+    function getOrderAgent(uint256 _orderId)
+        public
+        view
+        returns(address)
+    {
+        return orderBook[_orderId].agent;
+    }
+
+    function getOrderCanceled(uint256 _orderId)
+        public
+        view
+        returns(bool)
+    {
+        return orderBook[_orderId].canceled;
+    }
+
+    // -------------------------------------------------------------------
+    // 直近注文ID
+    // -------------------------------------------------------------------
+    uint256 public latestOrderId = 0;
+
+    function setLatestOrderId(uint256 _latestOrderId)
+        public
+        onlyLatestVersion()
+    {
+        latestOrderId = _latestOrderId;
+    }
+
+    function getLatestOrderId()
+        public
+        view
+        returns(uint256)
+    {
+        return latestOrderId;
+    }
+
+    // -------------------------------------------------------------------
+    // 約定情報
+    // -------------------------------------------------------------------
+    struct Agreement {
+        address counterpart; // 約定相手
+        uint256 amount; // 約定数量
+        uint256 price; // 約定価格
+        bool canceled; // キャンセル済みフラグ
+        bool paid; // 支払い済みフラグ
+        uint256 expiry; // 有効期限（約定から１４日）
+    }
+
+    // +++++++++++++++++++
+    // 約定情報
+    // orderId => agreementId => Agreement
+    // +++++++++++++++++++
+    mapping(uint256 => mapping(uint256 => Agreement)) public agreements;
+
+    function setAgreement(uint256 _orderId, uint256 _agreementId,
+        address _counterpart, uint256 _amount, uint256 _price,
+        bool _canceled, bool _paid, uint256 _expiry)
+        public
+        onlyLatestVersion()
+    {
+        agreements[_orderId][_agreementId].counterpart = _counterpart;
+        agreements[_orderId][_agreementId].amount = _amount;
+        agreements[_orderId][_agreementId].price = _price;
+        agreements[_orderId][_agreementId].canceled = _canceled;
+        agreements[_orderId][_agreementId].paid = _paid;
+        agreements[_orderId][_agreementId].expiry = _expiry;
+    }
+
+    function setAgreementCounterpart(uint256 _orderId, uint256 _agreementId, address _counterpart)
+        public
+        onlyLatestVersion()
+    {
+        agreements[_orderId][_agreementId].counterpart = _counterpart;
+    }
+
+    function setAgreementAmount(uint256 _orderId, uint256 _agreementId, uint256 _amount)
+        public
+        onlyLatestVersion()
+    {
+        agreements[_orderId][_agreementId].amount = _amount;
+    }
+
+    function setAgreementPrice(uint256 _orderId, uint256 _agreementId, uint256 _price)
+        public
+        onlyLatestVersion()
+    {
+        agreements[_orderId][_agreementId].price = _price;
+    }
+
+    function setAgreementCanceled(uint256 _orderId, uint256 _agreementId, bool _canceled)
+        public
+        onlyLatestVersion()
+    {
+        agreements[_orderId][_agreementId].canceled = _canceled;
+    }
+
+    function setAgreementPaid(uint256 _orderId, uint256 _agreementId, bool _paid)
+        public
+        onlyLatestVersion()
+    {
+        agreements[_orderId][_agreementId].paid = _paid;
+    }
+
+    function setAgreementExpiry(uint256 _orderId, uint256 _agreementId, uint256 _expiry)
+        public
+        onlyLatestVersion()
+    {
+        agreements[_orderId][_agreementId].expiry = _expiry;
+    }
+
+    function getAgreement(uint256 _orderId, uint256 _agreementId)
+        public
+        view
+        returns (address _counterpart, uint256 _amount, uint256 _price,
+        bool _canceled, bool _paid, uint256 _expiry)
+    {
+        return (
+            agreements[_orderId][_agreementId].counterpart,
+            agreements[_orderId][_agreementId].amount,
+            agreements[_orderId][_agreementId].price,
+            agreements[_orderId][_agreementId].canceled,
+            agreements[_orderId][_agreementId].paid,
+            agreements[_orderId][_agreementId].expiry
+        );
+    }
+
+    function getAgreementCounterpart(uint256 _orderId, uint256 _agreementId)
+        public
+        view
+        returns(address)
+    {
+        return agreements[_orderId][_agreementId].counterpart;
+    }
+
+    function getAgreementAmount(uint256 _orderId, uint256 _agreementId)
+        public
+        view
+        returns(uint256)
+    {
+        return agreements[_orderId][_agreementId].amount;
+    }
+
+    function getAgreementPrice(uint256 _orderId, uint256 _agreementId)
+        public
+        view
+        returns(uint256)
+    {
+        return agreements[_orderId][_agreementId].price;
+    }
+
+    function getAgreementCanceled(uint256 _orderId, uint256 _agreementId)
+        public
+        view
+        returns(bool)
+    {
+        return agreements[_orderId][_agreementId].canceled;
+    }
+
+    function getAgreementPaid(uint256 _orderId, uint256 _agreementId)
+        public
+        view
+        returns(bool)
+    {
+        return agreements[_orderId][_agreementId].paid;
+    }
+
+    function getAgreementExpiry(uint256 _orderId, uint256 _agreementId)
+        public
+        view
+        returns(uint256)
+    {
+        return agreements[_orderId][_agreementId].expiry;
+    }
+
+    // -------------------------------------------------------------------
+    // 直近約定ID
+    // orderId => latestAgreementId
+    // -------------------------------------------------------------------
+    mapping(uint256 => uint256) public latestAgreementIds;
+
+    function setLatestAgreementId(uint256 _orderId, uint256 _latestAgreementId)
+        public
+        onlyLatestVersion()
+    {
+        latestAgreementIds[_orderId] = _latestAgreementId;
+    }
+
+    function getLatestAgreementId(uint256 _orderId)
+        public
+        view
+        returns(uint256)
+    {
+        return latestAgreementIds[_orderId];
+    }
+
+    // -------------------------------------------------------------------
+    // 現在値
+    // token => latest_price
+    // -------------------------------------------------------------------
+    mapping(address => uint256) public lastPrice;
+
+    function setLastPrice(address _token, uint256 _value)
+        public
+        onlyLatestVersion()
+    {
+        lastPrice[_token] = _value;
+    }
+
+    function getLastPrice(address _token)
+        public
+        view
+        returns(uint256)
+    {
+        return lastPrice[_token];
+    }
+
+}

--- a/contracts/IbetCoupon.sol
+++ b/contracts/IbetCoupon.sol
@@ -46,10 +46,10 @@ contract IbetCoupon is Ownable, IbetStandardTokenInterface {
     event ApplyFor(address indexed accountAddress);
 
     // コンストラクタ
-    constructor(string _name, string _symbol,
+    constructor(string memory _name, string memory _symbol,
         uint256 _totalSupply, address _tradableExchange,
-        string _details, string _returnDetails,
-        string _memo, string _expirationDate,
+        string memory _details, string memory _returnDetails,
+        string memory _memo, string memory _expirationDate,
         bool _transferable)
         public
     {
@@ -77,7 +77,7 @@ contract IbetCoupon is Ownable, IbetStandardTokenInterface {
     }
 
     // ファンクション：アカウントアドレスへの振替
-    function transferToAddress(address _to, uint _value, bytes /*_data*/) private returns (bool success) {
+    function transferToAddress(address _to, uint _value, bytes memory /*_data*/) private returns (bool success) {
         balances[msg.sender] = balanceOf(msg.sender).sub(_value);
         balances[_to] = balanceOf(_to).add(_value);
         emit Transfer(msg.sender, _to, _value);
@@ -85,7 +85,7 @@ contract IbetCoupon is Ownable, IbetStandardTokenInterface {
     }
 
     // ファンクション：コントラクトアドレスへの振替
-    function transferToContract(address _to, uint _value, bytes _data) private returns (bool success) {
+    function transferToContract(address _to, uint _value, bytes memory _data) private returns (bool success) {
         require(_to == tradableExchange);
         balances[msg.sender] = balanceOf(msg.sender).sub(_value);
         balances[_to] = balanceOf(_to).add(_value);
@@ -192,13 +192,13 @@ contract IbetCoupon is Ownable, IbetStandardTokenInterface {
 
     // ファンクション：クーポン詳細を更新する
     // オーナーのみ実行可能
-    function setDetails(string _details) public onlyOwner() {
+    function setDetails(string memory _details) public onlyOwner() {
         details = _details;
     }
 
     // ファンクション：リターン詳細更新
     // オーナーのみ実行可能
-    function setReturnDetails(string _returnDetails)
+    function setReturnDetails(string memory _returnDetails)
         public
         onlyOwner()
     {
@@ -207,13 +207,13 @@ contract IbetCoupon is Ownable, IbetStandardTokenInterface {
 
     // ファンクション：メモ欄を更新する
     // オーナーのみ実行可能
-    function setMemo(string _memo) public onlyOwner() {
+    function setMemo(string memory _memo) public onlyOwner() {
         memo = _memo;
     }
 
     // ファンクション：有効期限更新
     // オーナーのみ実行可能
-    function setExpirationDate(string _expirationDate)
+    function setExpirationDate(string memory _expirationDate)
       public
       onlyOwner()
     {
@@ -238,12 +238,12 @@ contract IbetCoupon is Ownable, IbetStandardTokenInterface {
 
     // ファンクション：商品の画像を設定する
     // オーナーのみ実行可能
-    function setImageURL(uint8 _class, string _image_url) public onlyOwner() {
+    function setImageURL(uint8 _class, string memory _image_url) public onlyOwner() {
         image_urls[_class] = _image_url;
     }
 
     // ファンクション：商品の画像を取得する
-    function getImageURL(uint8 _class) public view returns (string) {
+    function getImageURL(uint8 _class) public view returns (string memory) {
         return image_urls[_class];
     }
 
@@ -257,7 +257,7 @@ contract IbetCoupon is Ownable, IbetStandardTokenInterface {
     }
 
     // ファンクション：募集申込
-    function applyForOffering(string _data)
+    function applyForOffering(string memory _data)
       public
     {
       // 申込ステータスが停止中の場合、エラーを返す

--- a/contracts/IbetMembership.sol
+++ b/contracts/IbetMembership.sol
@@ -39,10 +39,10 @@ contract IbetMembership is Ownable, IbetStandardTokenInterface {
   event ApplyFor(address indexed accountAddress);
 
   // コンストラクタ
-  constructor(string _name, string _symbol,
+  constructor(string memory _name, string memory _symbol,
     uint256 _initialSupply, address _tradableExchange,
-    string _details, string _returnDetails,
-    string _expirationDate, string _memo,
+    string memory _details, string memory _returnDetails,
+    string memory _expirationDate, string memory _memo,
     bool _transferable)
     public
   {
@@ -74,7 +74,7 @@ contract IbetMembership is Ownable, IbetStandardTokenInterface {
   }
 
   // ファンクション：アドレスへの振替
-  function transferToAddress(address _to, uint _value, bytes /*_data*/)
+  function transferToAddress(address _to, uint _value, bytes memory /*_data*/)
     private
     returns (bool success)
   {
@@ -88,7 +88,7 @@ contract IbetMembership is Ownable, IbetStandardTokenInterface {
   }
 
   // ファンクション：コントラクトへの振替
-  function transferToContract(address _to, uint _value, bytes _data)
+  function transferToContract(address _to, uint _value, bytes memory _data)
     private
     returns (bool success)
   {
@@ -165,7 +165,7 @@ contract IbetMembership is Ownable, IbetStandardTokenInterface {
 
   // ファンクション：会員権詳細更新
   // オーナーのみ実行可能
-  function setDetails(string _details)
+  function setDetails(string memory _details)
     public
     onlyOwner()
   {
@@ -174,7 +174,7 @@ contract IbetMembership is Ownable, IbetStandardTokenInterface {
 
   // ファンクション：リターン詳細更新
   // オーナーのみ実行可能
-  function setReturnDetails(string _returnDetails)
+  function setReturnDetails(string memory _returnDetails)
     public
     onlyOwner()
   {
@@ -183,7 +183,7 @@ contract IbetMembership is Ownable, IbetStandardTokenInterface {
 
   // ファンクション：有効期限更新
   // オーナーのみ実行可能
-  function setExpirationDate(string _expirationDate)
+  function setExpirationDate(string memory _expirationDate)
     public
     onlyOwner()
   {
@@ -192,7 +192,7 @@ contract IbetMembership is Ownable, IbetStandardTokenInterface {
 
   // ファンクション：メモ欄更新
   // オーナーのみ実行可能
-  function setMemo(string _memo)
+  function setMemo(string memory _memo)
     public
     onlyOwner()
   {
@@ -220,7 +220,7 @@ contract IbetMembership is Ownable, IbetStandardTokenInterface {
 
   // ファンクション：商品画像更新
   // オーナーのみ実行可能
-  function setImageURL(uint8 _class, string _image_url)
+  function setImageURL(uint8 _class, string memory _image_url)
     public
     onlyOwner()
   {
@@ -231,7 +231,7 @@ contract IbetMembership is Ownable, IbetStandardTokenInterface {
   function getImageURL(uint8 _class)
     public
     view
-    returns (string)
+    returns (string memory)
   {
     return image_urls[_class];
   }
@@ -256,7 +256,7 @@ contract IbetMembership is Ownable, IbetStandardTokenInterface {
   }
 
   // ファンクション：募集申込
-  function applyForOffering(string _data)
+  function applyForOffering(string memory _data)
     public
   {
     // 申込ステータスが停止中の場合、エラーを返す

--- a/contracts/IbetMembershipExchange.sol
+++ b/contracts/IbetMembershipExchange.sol
@@ -3,19 +3,72 @@ pragma solidity ^0.4.24;
 import "./SafeMath.sol";
 import "./Ownable.sol";
 import "./IbetMembership.sol";
+import "./ExchangeStorage.sol";
 import "./PaymentGateway.sol";
 
 contract IbetMembershipExchange is Ownable {
     using SafeMath for uint256;
-
-    address public paymentGatewayAddress;
 
     // 約定明細の有効期限
     //  Note:
     //   現在の設定値は14日で設定している（長期の連休を考慮）。
     uint256 lockingPeriod = 1209600;
 
-    // 注文情報
+    // ---------------------------------------------------------------
+    // Event
+    // ---------------------------------------------------------------
+
+    // Event：注文
+    event NewOrder(address indexed tokenAddress, uint256 orderId,
+        address indexed accountAddress, bool indexed isBuy, uint256 price,
+        uint256 amount, address agentAddress);
+
+    // Event：注文取消
+    event CancelOrder(address indexed tokenAddress, uint256 orderId,
+        address indexed accountAddress, bool indexed isBuy, uint256 price,
+        uint256 amount, address agentAddress);
+
+    // Event：約定
+    event Agree(address indexed tokenAddress, uint256 orderId,
+        uint256 agreementId, address indexed buyAddress,
+        address indexed sellAddress, uint256 price, uint256 amount,
+        address agentAddress);
+
+    // Event：決済OK
+    event SettlementOK(address indexed tokenAddress, uint256 orderId,
+        uint256 agreementId, address indexed buyAddress,
+        address indexed sellAddress, uint256 price, uint256 amount,
+        address agentAddress);
+
+    // Event：決済NG
+    event SettlementNG(address indexed tokenAddress, uint256 orderId,
+        uint256 agreementId, address indexed buyAddress,
+        address indexed sellAddress, uint256 price,
+        uint256 amount, address agentAddress);
+
+    // Event：全引き出し
+    event Withdrawal(address indexed tokenAddress, address indexed accountAddress);
+
+    // Event：送信
+    event Transfer(address indexed tokenAddress, address indexed from,
+        address indexed to, uint256 value);
+
+    // ---------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------
+    address public paymentGatewayAddress;
+    address public storageAddress;
+
+    constructor(address _paymentGatewayAddress, address _storageAddress)
+        public
+    {
+        paymentGatewayAddress = _paymentGatewayAddress;
+        storageAddress = _storageAddress;
+    }
+
+    // ---------------------------------------------------------------
+    // Function: Storage
+    // ---------------------------------------------------------------
     struct Order {
         address owner;
         address token;
@@ -26,7 +79,6 @@ contract IbetMembershipExchange is Ownable {
         bool canceled; // キャンセル済みフラグ
     }
 
-    // 約定情報
     struct Agreement {
         address counterpart; // 約定相手
         uint256 amount; // 約定数量
@@ -36,74 +88,138 @@ contract IbetMembershipExchange is Ownable {
         uint256 expiry; // 有効期限（約定から１４日）
     }
 
-    // 残高数量
-    // account => token => balance
-    mapping(address => mapping(address => uint256)) public balances;
-
-    // 拘束数量
-    // account => token => order commitment
-    mapping(address => mapping(address => uint256)) public commitments;
-
-    // 注文情報
-    // orderId => order
-    mapping(uint256 => Order) public orderBook;
-
-    // 直近注文ID
-    uint256 public latestOrderId = 0;
-
-    // 約定情報
-    // orderId => agreementId => Agreement
-    mapping(uint256 => mapping(uint256 => Agreement)) public agreements;
-
-    // 直近約定ID
-    // orderId => latestAgreementId
-    mapping(uint256 => uint256) public latestAgreementIds;
-
-    // 現在値
-    // token => latest_price
-    mapping(address => uint256) public lastPrice;
-
-    // イベント：注文
-    event NewOrder(address indexed tokenAddress, uint256 orderId,
-        address indexed accountAddress, bool indexed isBuy, uint256 price,
-        uint256 amount, address agentAddress);
-
-    // イベント：注文取消
-    event CancelOrder(address indexed tokenAddress, uint256 orderId,
-        address indexed accountAddress, bool indexed isBuy, uint256 price,
-        uint256 amount, address agentAddress);
-
-    // イベント：約定
-    event Agree(address indexed tokenAddress, uint256 orderId,
-        uint256 agreementId, address indexed buyAddress,
-        address indexed sellAddress, uint256 price, uint256 amount,
-        address agentAddress);
-
-    // イベント：決済OK
-    event SettlementOK(address indexed tokenAddress, uint256 orderId,
-        uint256 agreementId, address indexed buyAddress,
-        address indexed sellAddress, uint256 price, uint256 amount,
-        address agentAddress);
-
-    // イベント：決済NG
-    event SettlementNG(address indexed tokenAddress, uint256 orderId,
-        uint256 agreementId, address indexed buyAddress,
-        address indexed sellAddress, uint256 price,
-        uint256 amount, address agentAddress);
-
-    // イベント：全引き出し
-    event Withdrawal(address indexed tokenAddress, address indexed accountAddress);
-
-    // イベント：送信
-    event Transfer(address indexed tokenAddress, address indexed from,
-        address indexed to, uint256 value);
-
-    // コンストラクタ
-    constructor(address _paymentGatewayAddress) public {
-        paymentGatewayAddress = _paymentGatewayAddress;
+    // Order
+    function getOrder(uint256 _orderId)
+        public
+        view
+        returns (address owner, address token, uint256 amount, uint256 price,
+        bool isBuy, address agent, bool canceled)
+    {
+        return ExchangeStorage(storageAddress).getOrder(_orderId);
     }
 
-    // ファンクション：（投資家）新規注文を作成する　Make注文
+    function setOrder(
+        uint256 _orderId, address _owner, address _token,
+        uint256 _amount, uint256 _price, bool _isBuy,
+        address _agent, bool _canceled)
+        private
+        returns (bool)
+    {
+        ExchangeStorage(storageAddress).setOrder(
+            _orderId, _owner, _token, _amount, _price, _isBuy, _agent, _canceled);
+        return true;
+    }
+
+    // Agreement
+    function getAgreement(uint256 _orderId, uint256 _agreementId)
+        public
+        view
+        returns (address _counterpart, uint256 _amount, uint256 _price,
+        bool _canceled, bool _paid, uint256 _expiry)
+    {
+        return ExchangeStorage(storageAddress).getAgreement(_orderId, _agreementId);
+    }
+
+    function setAgreement(uint256 _orderId, uint256 _agreementId,
+        address _counterpart, uint256 _amount, uint256 _price,
+        bool _canceled, bool _paid, uint256 _expiry)
+        private
+        returns (bool)
+    {
+        ExchangeStorage(storageAddress).setAgreement(
+            _orderId, _agreementId, _counterpart, _amount, _price, _canceled, _paid, _expiry);
+        return true;
+    }
+
+    // Latest Order ID
+    function latestOrderId()
+        public
+        view
+        returns (uint256)
+    {
+        return ExchangeStorage(storageAddress).getLatestOrderId();
+    }
+
+    function setLatestOrderId(uint256 _value)
+        private
+        returns (bool)
+    {
+        ExchangeStorage(storageAddress).setLatestOrderId(_value);
+        return true;
+    }
+
+    // Latest Agreement ID
+    function latestAgreementId(uint256 _orderId)
+        public
+        view
+        returns (uint256)
+    {
+        return ExchangeStorage(storageAddress).getLatestAgreementId(_orderId);
+    }
+
+    function setLatestAgreementId(uint256 _orderId, uint256 _value)
+        private
+        returns (bool)
+    {
+        ExchangeStorage(storageAddress).setLatestAgreementId(_orderId, _value);
+        return true;
+    }
+
+    // Balance
+    function balanceOf(address _account, address _token)
+        public
+        view
+        returns (uint256)
+    {
+        return ExchangeStorage(storageAddress).getBalance(_account, _token);
+    }
+
+    function setBalance(address _account, address _token, uint256 _value)
+        private
+        returns (bool)
+    {
+        return ExchangeStorage(storageAddress).setBalance(_account, _token, _value);
+    }
+
+    // Commitment
+    function commitmentOf(address _account, address _token)
+        public
+        view
+        returns (uint256)
+    {
+        return ExchangeStorage(storageAddress).getCommitment(_account, _token);
+    }
+
+    function setCommitment(address _account, address _token, uint256 _value)
+        private
+        returns (bool)
+    {
+        ExchangeStorage(storageAddress).setCommitment(_account, _token, _value);
+        return true;
+    }
+
+    // LastPrice
+    function lastPrice(address _token)
+        public
+        view
+        returns(uint256)
+    {
+        return ExchangeStorage(storageAddress).getLastPrice(_token);
+    }
+
+    function setLastPrice(address _token, uint256 _value)
+        private
+        returns (bool)
+    {
+        ExchangeStorage(storageAddress).setLastPrice(_token, _value);
+        return true;
+    }
+
+    // ---------------------------------------------------------------
+    // Function: Logic
+    // ---------------------------------------------------------------
+
+    // Function：（投資家）新規注文を作成する　Make注文
     function createOrder(address _token, uint256 _amount, uint256 _price,
         bool _isBuy, address _agent)
         public
@@ -133,25 +249,25 @@ contract IbetMembershipExchange is Ownable {
             //  4) 有効な収納代行業者（Agent）を指定していない場合
             //   -> 更新処理：全ての残高を投資家のアカウントに戻し、falseを返す
             if (_amount == 0 ||
-                balances[msg.sender][_token] < _amount ||
+                balanceOf(msg.sender, _token) < _amount ||
                 IbetMembership(_token).status() == false ||
                 validateAgent(_agent) == false)
             {
-                IbetMembership(_token).transfer(msg.sender,balances[msg.sender][_token]);
-                balances[msg.sender][_token] = 0;
+                IbetMembership(_token).transfer(msg.sender, balanceOf(msg.sender, _token));
+                setBalance(msg.sender, _token, 0);
                 return false;
             }
         }
 
         // 更新処理：注文IDをカウントアップ -> 注文情報を挿入
-        uint256 orderId = latestOrderId++;
-        orderBook[orderId] = Order(msg.sender, _token, _amount, _price,
-                                  _isBuy, _agent, false);
+        uint256 orderId = latestOrderId() + 1;
+        setLatestOrderId(orderId);
+        setOrder(orderId, msg.sender, _token, _amount, _price, _isBuy, _agent, false);
 
         // 更新処理：売り注文の場合、預かりを拘束
         if (!_isBuy) {
-            balances[msg.sender][_token] = balances[msg.sender][_token].sub(_amount);
-            commitments[msg.sender][_token] = commitments[msg.sender][_token].add(_amount);
+            setBalance(msg.sender, _token, balanceOf(msg.sender, _token).sub(_amount));
+            setCommitment(msg.sender, _token, commitmentOf(msg.sender, _token).add(_amount));
         }
 
         // イベント登録：新規注文
@@ -160,14 +276,19 @@ contract IbetMembershipExchange is Ownable {
         return true;
     }
 
-    // ファンクション：（投資家）注文をキャンセルする
-    function cancelOrder(uint256 _orderId) public returns (bool) {
+    // Function：（投資家）注文をキャンセルする
+    function cancelOrder(uint256 _orderId)
+        public
+        returns (bool)
+    {
         // <CHK>
         //  指定した注文番号が、直近の注文ID以上の場合
         //   -> REVERT
-        require(_orderId < latestOrderId);
+        require(_orderId <= latestOrderId());
 
-        Order storage order = orderBook[_orderId];
+        Order memory order;
+        (order.owner, order.token, order.amount, order.price, order.isBuy, order.agent, order.canceled) =
+            getOrder(_orderId);
 
         // <CHK>
         //  1) 元注文の残注文数量が0の場合
@@ -182,13 +303,12 @@ contract IbetMembershipExchange is Ownable {
 
         // 更新処理：売り注文の場合、注文で拘束している預かりを解放 => 残高を投資家のアカウントに戻す
         if (!order.isBuy) {
-            commitments[msg.sender][order.token] =
-                commitments[msg.sender][order.token].sub(order.amount);
+            setCommitment(msg.sender, order.token, commitmentOf(msg.sender, order.token).sub(order.amount));
             IbetMembership(order.token).transfer(msg.sender,order.amount);
         }
 
         // 更新処理：キャンセル済みフラグをキャンセル済み（True）に更新
-        order.canceled = true;
+        setOrder(_orderId, order.owner, order.token, order.amount, order.price, order.isBuy, order.agent, true);
 
         // イベント登録：注文キャンセル
         emit CancelOrder(order.token, _orderId, msg.sender,
@@ -197,16 +317,19 @@ contract IbetMembershipExchange is Ownable {
         return true;
     }
 
-    // ファンクション：（投資家）注文に応じる　Take注文 -> 約定
+    // Function：（投資家）注文に応じる　Take注文 -> 約定
     function executeOrder(uint256 _orderId, uint256 _amount, bool _isBuy)
         public
         returns (bool)
     {
         // <CHK>
         //  指定した注文IDが直近の注文IDを超えている場合
-        require(_orderId < latestOrderId);
+        require(_orderId <= latestOrderId());
 
-        Order storage order = orderBook[_orderId];
+        Order memory order;
+        (order.owner, order.token, order.amount, order.price, order.isBuy, order.agent, order.canceled) =
+            getOrder(_orderId);
+
         require(order.owner != 0x0000000000000000000000000000000000000000);
 
         if (_isBuy == true) { // 買注文の場合
@@ -246,47 +369,45 @@ contract IbetMembershipExchange is Ownable {
                 msg.sender == order.owner ||
                 order.canceled == true ||
                 IbetMembership(order.token).status() == false ||
-                balances[msg.sender][order.token] < _amount ||
+                balanceOf(msg.sender, order.token) < _amount ||
                 order.amount < _amount )
             {
-                IbetMembership(order.token).transfer(msg.sender,
-                    balances[msg.sender][order.token]);
-                balances[msg.sender][order.token] = 0;
+                IbetMembership(order.token).transfer(msg.sender, balanceOf(msg.sender, order.token));
+                setBalance(msg.sender, order.token, 0);
                 return false;
             }
         }
 
         // 更新処理：約定IDをカウントアップ => 約定情報を挿入する
-        uint256 latestAgreementId = latestAgreementIds[_orderId]++;
-        uint256 _expiry = now + lockingPeriod;
-        agreements[_orderId][latestAgreementId] =
-            Agreement(msg.sender, _amount, order.price, false, false, _expiry);
+        uint256 agreementId = latestAgreementId(_orderId) + 1;
+        setLatestAgreementId(_orderId, agreementId);
+        uint256 expiry = now + lockingPeriod;
+        setAgreement(_orderId, agreementId, msg.sender, _amount, order.price, false, false, expiry);
 
         // 更新処理：元注文の数量を減らす
-        order.amount = order.amount.sub(_amount);
+        setOrder(_orderId, order.owner, order.token, order.amount.sub(_amount),
+            order.price, order.isBuy, order.agent, order.canceled);
 
         if (order.isBuy) {
             // 更新処理：買い注文に対して売り注文で応じた場合、売りの預かりを拘束
-            balances[msg.sender][order.token] =
-                balances[msg.sender][order.token].sub(_amount);
-            commitments[msg.sender][order.token] =
-                commitments[msg.sender][order.token].add(_amount);
+            setBalance(msg.sender, order.token, balanceOf(msg.sender, order.token).sub(_amount));
+            setCommitment(msg.sender, order.token, commitmentOf(msg.sender, order.token).add(_amount));
             // イベント登録：約定
-            emit Agree(order.token, _orderId, latestAgreementId, order.owner,
+            emit Agree(order.token, _orderId, agreementId, order.owner,
                 msg.sender, order.price, _amount, order.agent);
         } else {
             // イベント登録：約定
-            emit Agree(order.token, _orderId, latestAgreementId,
+            emit Agree(order.token, _orderId, agreementId,
                 msg.sender, order.owner, order.price, _amount, order.agent);
         }
 
         // 更新処理：現在値を更新する
-        lastPrice[order.token] = order.price;
+        setLastPrice(order.token, order.price);
 
         return true;
     }
 
-    // ファンクション：（決済業者）決済処理 -> 預かりの移動 -> 預かりの引き出し
+    // Function：（決済業者）決済処理 -> 預かりの移動 -> 預かりの引き出し
     function confirmAgreement(uint256 _orderId, uint256 _agreementId)
         public
         returns (bool)
@@ -295,11 +416,18 @@ contract IbetMembershipExchange is Ownable {
         //  1) 指定した注文番号が、直近の注文ID以上の場合
         //  2) 指定した約定IDが、直近の約定ID以上の場合
         //   -> REVERT
-        require(_orderId < latestOrderId);
-        require(_agreementId < latestAgreementIds[_orderId]);
+        require(_orderId <= latestOrderId());
+        require(_agreementId <= latestAgreementId(_orderId));
 
-        Order storage order = orderBook[_orderId];
-        Agreement storage agreement = agreements[_orderId][_agreementId];
+        Order memory order;
+        (order.owner, order.token, order.amount, order.price, order.isBuy,
+            order.agent, order.canceled) =
+                getOrder(_orderId);
+
+        Agreement memory agreement;
+        (agreement.counterpart, agreement.amount, agreement.price,
+            agreement.canceled, agreement.paid, agreement.expiry) =
+                getAgreement(_orderId, _agreementId);
 
         // <CHK>
         //  1) すでに決済承認済み（支払い済み）の場合
@@ -313,12 +441,14 @@ contract IbetMembershipExchange is Ownable {
         }
 
         // 更新処理：支払い済みフラグを支払い済み（True）に更新する
-        agreement.paid = true;
+        setAgreement(_orderId, _agreementId, agreement.counterpart, agreement.amount, agreement.price,
+            agreement.canceled, true, agreement.expiry);
 
         if (order.isBuy) {
             // 更新処理：買注文の場合、突合相手（売り手）から注文者（買い手）へと資産移転を行う
-            commitments[agreement.counterpart][order.token] =
-                commitments[agreement.counterpart][order.token].sub(agreement.amount);
+            setCommitment(
+                agreement.counterpart, order.token,
+                    commitmentOf(agreement.counterpart, order.token).sub(agreement.amount));
             IbetMembership(order.token).transfer(order.owner,agreement.amount);
             // イベント登録：決済OK
             emit SettlementOK(order.token, _orderId, _agreementId,
@@ -326,10 +456,10 @@ contract IbetMembershipExchange is Ownable {
                 agreement.amount, order.agent);
         } else {
             // 更新処理：売注文の場合、注文者（売り手）から突合相手（買い手）へと資産移転を行う
-            commitments[order.owner][order.token] =
-                commitments[order.owner][order.token].sub(agreement.amount);
-            IbetMembership(order.token).transfer(agreement.counterpart,
-                                                  agreement.amount);
+            setCommitment(
+                order.owner, order.token,
+                    commitmentOf(order.owner, order.token).sub(agreement.amount));
+            IbetMembership(order.token).transfer(agreement.counterpart, agreement.amount);
             // イベント登録：決済OK
             emit SettlementOK(order.token, _orderId, _agreementId,
                 agreement.counterpart, order.owner, order.price,
@@ -339,7 +469,7 @@ contract IbetMembershipExchange is Ownable {
         return true;
     }
 
-    // ファンクション：（決済業者）約定キャンセル
+    // Function：（決済業者）約定キャンセル
     function cancelAgreement(uint256 _orderId, uint256 _agreementId)
         public
         returns (bool)
@@ -348,11 +478,18 @@ contract IbetMembershipExchange is Ownable {
         //  1) 指定した注文番号が、直近の注文ID以上の場合
         //  2) 指定した約定IDが、直近の約定ID以上の場合
         //   -> REVERT
-        require(_orderId < latestOrderId);
-        require(_agreementId < latestAgreementIds[_orderId]);
+        require(_orderId <= latestOrderId());
+        require(_agreementId <= latestAgreementId(_orderId));
 
-        Order storage order = orderBook[_orderId];
-        Agreement storage agreement = agreements[_orderId][_agreementId];
+        Order memory order;
+        (order.owner, order.token, order.amount, order.price, order.isBuy,
+            order.agent, order.canceled) =
+                getOrder(_orderId);
+
+        Agreement memory agreement;
+        (agreement.counterpart, agreement.amount, agreement.price,
+            agreement.canceled, agreement.paid, agreement.expiry) =
+                getAgreement(_orderId, _agreementId);
 
         if (agreement.expiry <= now) { // 約定明細の有効期限を超過している場合
           // <CHK>
@@ -385,15 +522,15 @@ contract IbetMembershipExchange is Ownable {
         }
 
         // 更新処理：キャンセル済みフラグをキャンセル（True）に更新する
-        agreements[_orderId][_agreementId].canceled = true;
+        setAgreement(_orderId, _agreementId, agreement.counterpart, agreement.amount, agreement.price,
+            true, agreement.paid, agreement.expiry);
 
         if (order.isBuy) {
             // 更新処理：買い注文の場合、突合相手（売り手）の預かりを解放 -> 預かりの引き出し
             // 取り消した注文は無効化する（注文中状態に戻さない）
-            commitments[agreement.counterpart][order.token] =
-                commitments[agreement.counterpart][order.token].sub(agreement.amount);
-            IbetMembership(order.token).transfer(agreement.counterpart,
-                                                  agreement.amount);
+            setCommitment(agreement.counterpart, order.token,
+                commitmentOf(agreement.counterpart, order.token).sub(agreement.amount));
+            IbetMembership(order.token).transfer(agreement.counterpart, agreement.amount);
             // イベント登録：決済NG
             emit SettlementNG(order.token, _orderId, _agreementId,
                 order.owner, agreement.counterpart, order.price,
@@ -402,8 +539,8 @@ contract IbetMembershipExchange is Ownable {
             // 更新処理：売り注文の場合、突合相手（買い手）の注文数量だけ注文者（売り手）の預かりを解放
             //  -> 預かりの引き出し。
             // 取り消した注文は無効化する（注文中状態に戻さない）
-            commitments[order.owner][order.token] =
-                commitments[order.owner][order.token].sub(agreement.amount);
+            setCommitment(order.owner, order.token,
+                commitmentOf(order.owner, order.token).sub(agreement.amount));
             IbetMembership(order.token).transfer(order.owner,agreement.amount);
             // イベント登録：決済NG
             emit SettlementNG(order.token, _orderId, _agreementId,
@@ -414,19 +551,23 @@ contract IbetMembershipExchange is Ownable {
         return true;
     }
 
-    // ファンクション：（投資家）全ての預かりを引き出しする
+    // Function：（投資家）全ての預かりを引き出しする
     //  Note:
-    //   未売却の預かり（balances）に対してのみ引き出しをおこなう。
+    //   未売却の預かりに対してのみ引き出しをおこなう。
     //   約定済、注文中の預かり（commitments）の引き出しはおこなわない。
-    function withdrawAll(address _token) public returns (bool) {
+    function withdrawAll(address _token)
+        public
+        returns (bool)
+    {
+        uint256 balance = balanceOf(msg.sender, _token);
 
         // <CHK>
         //  残高がゼロの場合、REVERT
-        if (balances[msg.sender][_token] == 0 ) { revert(); }
+        if (balance == 0 ) { revert(); }
 
         // 更新処理：トークン引き出し（送信）
-        IbetMembership(_token).transfer(msg.sender,balances[msg.sender][_token]);
-        balances[msg.sender][_token] = 0;
+        IbetMembership(_token).transfer(msg.sender, balance);
+        setBalance(msg.sender, _token, 0);
 
         // イベント登録
         emit Withdrawal(_token, msg.sender);
@@ -434,25 +575,25 @@ contract IbetMembershipExchange is Ownable {
         return true;
     }
 
-    // ファンクション：トークンを送信する
+    // Function：トークンを送信する
     function transfer(address _token, address _to, uint256 _value)
         public
         returns (bool)
     {
+        uint256 balance = balanceOf(msg.sender, _token);
+
         // <CHK>
         //  1) 送信数量が0の場合
         //  2) 残高数量が送信数量に満たない場合
         //   -> 更新処理：全ての残高をsenderのアカウントに戻し、falseを返す
-        if (_value == 0 ||
-            balances[msg.sender][_token] < _value) {
-            IbetMembership(_token).transfer(msg.sender,
-                                              balances[msg.sender][_token]);
-            balances[msg.sender][_token] = 0;
+        if (_value == 0 || balance < _value) {
+            IbetMembership(_token).transfer(msg.sender, balance);
+            setBalance(msg.sender, _token, 0);
             return false;
         }
 
         // 更新処理：トークン送信
-        balances[msg.sender][_token] = balances[msg.sender][_token].sub(_value);
+        setBalance(msg.sender, _token, balance.sub(_value));
         IbetMembership(_token).transfer(_to, _value);
 
         // イベント登録
@@ -461,12 +602,14 @@ contract IbetMembershipExchange is Ownable {
         return true;
     }
 
-    // ERC223 token deposit handler
-    function tokenFallback(address _from, uint _value, bytes /*_data*/) public{
-        balances[_from][msg.sender] = balances[_from][msg.sender].add(_value);
+    // Function： Deposit Handler
+    function tokenFallback(address _from, uint _value, bytes memory /*_data*/)
+        public
+    {
+        setBalance(_from, msg.sender, balanceOf(_from, msg.sender).add(_value));
     }
 
-    // ファンクション：アドレスフォーマットがコントラクトのものかを判断する
+    // Function：アドレスフォーマットがコントラクトのものかを判断する
     function isContract(address _addr)
       private
       view
@@ -479,7 +622,7 @@ contract IbetMembershipExchange is Ownable {
       return (length>0);
     }
 
-    // ファンクション：新規注文時に指定したagentアドレスが有効なアドレスであることをチェックする
+    // Function：新規注文時に指定したagentアドレスが有効なアドレスであることをチェックする
     function validateAgent(address _addr)
         private
         view

--- a/contracts/IbetStraightBond.sol
+++ b/contracts/IbetStraightBond.sol
@@ -47,12 +47,12 @@ contract IbetStraightBond is Ownable, IbetStandardTokenInterface {
     event Redeem();
 
     // コンストラクタ
-    constructor(string _name, string _symbol,
+    constructor(string memory _name, string memory _symbol,
         uint256 _totalSupply, address _tradableExchange,
-        uint256 _faceValue, uint256 _interestRate, string _interestPaymentDate,
-        string _redemptionDate, uint256 _redemptionAmount,
-        string _returnDate, string _returnAmount,
-        string _purpose, string _memo) public {
+        uint256 _faceValue, uint256 _interestRate, string memory _interestPaymentDate,
+        string memory _redemptionDate, uint256 _redemptionAmount,
+        string memory _returnDate, string memory _returnAmount,
+        string memory _purpose, string memory _memo) public {
         owner = msg.sender;
         name = _name;
         symbol = _symbol;
@@ -81,7 +81,7 @@ contract IbetStraightBond is Ownable, IbetStandardTokenInterface {
     }
 
     // ファンクション：アドレスへの振替
-    function transferToAddress(address _to, uint _value, bytes /*_data*/)
+    function transferToAddress(address _to, uint _value, bytes memory /*_data*/)
         private
         returns (bool success)
     {
@@ -95,7 +95,7 @@ contract IbetStraightBond is Ownable, IbetStandardTokenInterface {
     }
 
     // ファンクション：コントラクトへの振替
-    function transferToContract(address _to, uint _value, bytes _data)
+    function transferToContract(address _to, uint _value, bytes memory _data)
         private
         returns (bool success)
     {
@@ -191,17 +191,17 @@ contract IbetStraightBond is Ownable, IbetStandardTokenInterface {
     }
 
     // ファンクション：商品の画像を設定する
-    function setImageURL(uint8 _class, string _image_url) public onlyOwner() {
+    function setImageURL(uint8 _class, string memory _image_url) public onlyOwner() {
         image_urls[_class] = _image_url;
     }
 
     // ファンクション：商品の画像を取得する
-    function getImageURL(uint8 _class) public view returns (string) {
+    function getImageURL(uint8 _class) public view returns (string memory) {
         return image_urls[_class];
     }
 
     // メモ欄を更新する
-    function updateMemo(string _memo) public onlyOwner() {
+    function updateMemo(string memory _memo) public onlyOwner() {
         memo = _memo;
     }
 

--- a/contracts/IbetStraightBondExchange.sol
+++ b/contracts/IbetStraightBondExchange.sol
@@ -3,21 +3,75 @@ pragma solidity ^0.4.24;
 import "./SafeMath.sol";
 import "./Ownable.sol";
 import "./IbetStraightBond.sol";
+import "./ExchangeStorage.sol";
 import "./PaymentGateway.sol";
 import "./PersonalInfo.sol";
 
 contract IbetStraightBondExchange is Ownable {
     using SafeMath for uint256;
 
-    address public personalInfoAddress;
-    address public paymentGatewayAddress;
-
     // 約定明細の有効期限
     //  Note:
     //   現在の設定値は14日で設定している（長期の連休を考慮）。
     uint256 lockingPeriod = 1209600;
 
-    // 注文情報
+    // ---------------------------------------------------------------
+    // Event
+    // ---------------------------------------------------------------
+
+    // Event：注文
+    event NewOrder(address indexed tokenAddress, uint256 orderId,
+        address indexed accountAddress, bool indexed isBuy, uint256 price,
+        uint256 amount, address agentAddress);
+
+    // Event：注文取消
+    event CancelOrder(address indexed tokenAddress, uint256 orderId,
+        address indexed accountAddress, bool indexed isBuy, uint256 price,
+        uint256 amount, address agentAddress);
+
+    // Event：約定
+    event Agree(address indexed tokenAddress, uint256 orderId,
+        uint256 agreementId, address indexed buyAddress,
+        address indexed sellAddress, uint256 price, uint256 amount,
+        address agentAddress);
+
+    // Event：決済OK
+    event SettlementOK(address indexed tokenAddress, uint256 orderId,
+        uint256 agreementId, address indexed buyAddress,
+        address indexed sellAddress, uint256 price, uint256 amount,
+        address agentAddress);
+
+    // Event：決済NG
+    event SettlementNG(address indexed tokenAddress, uint256 orderId,
+        uint256 agreementId, address indexed buyAddress,
+        address indexed sellAddress, uint256 price,
+        uint256 amount, address agentAddress);
+
+    // Event：全引き出し
+    event Withdrawal(address indexed tokenAddress, address indexed accountAddress);
+
+    // Event：送信
+    event Transfer(address indexed tokenAddress, address indexed from,
+        address indexed to, uint256 value);
+
+    // ---------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------
+    address public personalInfoAddress;
+    address public paymentGatewayAddress;
+    address public storageAddress;
+
+    constructor(address _paymentGatewayAddress, address _personalInfoAddress, address _storageAddress)
+        public
+    {
+        paymentGatewayAddress = _paymentGatewayAddress;
+        personalInfoAddress = _personalInfoAddress;
+        storageAddress = _storageAddress;
+    }
+
+    // ---------------------------------------------------------------
+    // Function: Storage
+    // ---------------------------------------------------------------
     struct Order {
         address owner;
         address token;
@@ -28,7 +82,6 @@ contract IbetStraightBondExchange is Ownable {
         bool canceled; // キャンセル済みフラグ
     }
 
-    // 約定情報
     struct Agreement {
         address counterpart; // 約定相手
         uint256 amount; // 約定数量
@@ -38,81 +91,143 @@ contract IbetStraightBondExchange is Ownable {
         uint256 expiry; // 有効期限（約定から１４日）
     }
 
-    // 残高数量
-    // account => token => balance
-    mapping(address => mapping(address => uint256)) public balances;
-
-    // 拘束数量
-    // account => token => order commitment
-    mapping(address => mapping(address => uint256)) public commitments;
-
-    // 注文情報
-    // orderId => order
-    mapping(uint256 => Order) public orderBook;
-
-    // 直近注文ID
-    uint256 public latestOrderId = 0;
-
-    // 約定情報
-    // orderId => agreementId => Agreement
-    mapping(uint256 => mapping(uint256 => Agreement)) public agreements;
-
-    // 直近約定ID
-    // orderId => latestAgreementId
-    mapping(uint256 => uint256) public latestAgreementIds;
-
-    // 現在値
-    // token => latest_price
-    mapping(address => uint256) public lastPrice;
-
-    // イベント：注文
-    event NewOrder(address indexed tokenAddress, uint256 orderId,
-        address indexed accountAddress, bool indexed isBuy, uint256 price,
-        uint256 amount, address agentAddress);
-
-    // イベント：注文取消
-    event CancelOrder(address indexed tokenAddress, uint256 orderId,
-        address indexed accountAddress, bool indexed isBuy, uint256 price,
-        uint256 amount, address agentAddress);
-
-    // イベント：約定
-    event Agree(address indexed tokenAddress, uint256 orderId,
-        uint256 agreementId, address indexed buyAddress,
-        address indexed sellAddress, uint256 price, uint256 amount,
-        address agentAddress);
-
-    // イベント：決済OK
-    event SettlementOK(address indexed tokenAddress, uint256 orderId,
-        uint256 agreementId, address indexed buyAddress,
-        address indexed sellAddress, uint256 price, uint256 amount,
-        address agentAddress);
-
-    // イベント：決済NG
-    event SettlementNG(address indexed tokenAddress, uint256 orderId,
-        uint256 agreementId, address indexed buyAddress,
-        address indexed sellAddress, uint256 price,
-        uint256 amount, address agentAddress);
-
-    // イベント：全引き出し
-    event Withdrawal(address indexed tokenAddress, address indexed accountAddress);
-
-    // イベント：送信
-    event Transfer(address indexed tokenAddress, address indexed from,
-        address indexed to, uint256 value);
-
-    // コンストラクタ
-    constructor(address _paymentGatewayAddress, address _personalInfoAddress) public {
-        paymentGatewayAddress = _paymentGatewayAddress;
-        personalInfoAddress = _personalInfoAddress;
+    // Order
+    function getOrder(uint256 _orderId)
+        public
+        view
+        returns (address owner, address token, uint256 amount, uint256 price,
+        bool isBuy, address agent, bool canceled)
+    {
+        return ExchangeStorage(storageAddress).getOrder(_orderId);
     }
 
-    // ファンクション：（投資家）新規注文を作成する　Make注文
+    function setOrder(
+        uint256 _orderId, address _owner, address _token,
+        uint256 _amount, uint256 _price, bool _isBuy,
+        address _agent, bool _canceled)
+        private
+        returns (bool)
+    {
+        ExchangeStorage(storageAddress).setOrder(
+            _orderId, _owner, _token, _amount, _price, _isBuy, _agent, _canceled);
+        return true;
+    }
+
+    // Agreement
+    function getAgreement(uint256 _orderId, uint256 _agreementId)
+        public
+        view
+        returns (address _counterpart, uint256 _amount, uint256 _price,
+        bool _canceled, bool _paid, uint256 _expiry)
+    {
+        return ExchangeStorage(storageAddress).getAgreement(_orderId, _agreementId);
+    }
+
+    function setAgreement(uint256 _orderId, uint256 _agreementId,
+        address _counterpart, uint256 _amount, uint256 _price,
+        bool _canceled, bool _paid, uint256 _expiry)
+        private
+        returns (bool)
+    {
+        ExchangeStorage(storageAddress).setAgreement(
+            _orderId, _agreementId, _counterpart, _amount, _price, _canceled, _paid, _expiry);
+        return true;
+    }
+
+    // Latest Order ID
+    function latestOrderId()
+        public
+        view
+        returns (uint256)
+    {
+        return ExchangeStorage(storageAddress).getLatestOrderId();
+    }
+
+    function setLatestOrderId(uint256 _value)
+        private
+        returns (bool)
+    {
+        ExchangeStorage(storageAddress).setLatestOrderId(_value);
+        return true;
+    }
+
+    // Latest Agreement ID
+    function latestAgreementId(uint256 _orderId)
+        public
+        view
+        returns (uint256)
+    {
+        return ExchangeStorage(storageAddress).getLatestAgreementId(_orderId);
+    }
+
+    function setLatestAgreementId(uint256 _orderId, uint256 _value)
+        private
+        returns (bool)
+    {
+        ExchangeStorage(storageAddress).setLatestAgreementId(_orderId, _value);
+        return true;
+    }
+
+    // Balance
+    function balanceOf(address _account, address _token)
+        public
+        view
+        returns (uint256)
+    {
+        return ExchangeStorage(storageAddress).getBalance(_account, _token);
+    }
+
+    function setBalance(address _account, address _token, uint256 _value)
+        private
+        returns (bool)
+    {
+        return ExchangeStorage(storageAddress).setBalance(_account, _token, _value);
+    }
+
+    // Commitment
+    function commitmentOf(address _account, address _token)
+        public
+        view
+        returns (uint256)
+    {
+        return ExchangeStorage(storageAddress).getCommitment(_account, _token);
+    }
+
+    function setCommitment(address _account, address _token, uint256 _value)
+        private
+        returns (bool)
+    {
+        ExchangeStorage(storageAddress).setCommitment(_account, _token, _value);
+        return true;
+    }
+
+    // LastPrice
+    function lastPrice(address _token)
+        public
+        view
+        returns(uint256)
+    {
+        return ExchangeStorage(storageAddress).getLastPrice(_token);
+    }
+
+    function setLastPrice(address _token, uint256 _value)
+        private
+        returns (bool)
+    {
+        ExchangeStorage(storageAddress).setLastPrice(_token, _value);
+        return true;
+    }
+
+    // ---------------------------------------------------------------
+    // Function: Logic
+    // ---------------------------------------------------------------
+
+    // Function：（投資家）新規注文を作成する　Make注文
     function createOrder(address _token, uint256 _amount, uint256 _price,
         bool _isBuy, address _agent)
         public
         returns (bool)
     {
-
         if (_isBuy == true) { // 買注文の場合
             // <CHK>
             //  1) 注文数量が0の場合
@@ -144,28 +259,28 @@ contract IbetStraightBondExchange is Ownable {
             //  6) 有効な収納代行業者（Agent）を指定していない場合
             //   -> 更新処理：全ての残高を投資家のアカウントに戻し、falseを返す
             if (_amount == 0 ||
-                balances[msg.sender][_token] < _amount ||
+                balanceOf(msg.sender, _token) < _amount ||
                 PaymentGateway(paymentGatewayAddress).accountApproved(msg.sender,_agent) == false ||
                 PersonalInfo(personalInfoAddress).isRegistered(
                     msg.sender,IbetStraightBond(_token).owner()) == false ||
                 IbetStraightBond(_token).isRedeemed() == true ||
                 validateAgent(_agent) == false)
             {
-                IbetStraightBond(_token).transfer(msg.sender,balances[msg.sender][_token]);
-                balances[msg.sender][_token] = 0;
+                IbetStraightBond(_token).transfer(msg.sender, balanceOf(msg.sender, _token));
+                setBalance(msg.sender, _token, 0);
                 return false;
             }
         }
 
         // 更新処理：注文IDをカウントアップ -> 注文情報を挿入
-        uint256 orderId = latestOrderId++;
-        orderBook[orderId] = Order(msg.sender, _token, _amount, _price,
-                                  _isBuy, _agent, false);
+        uint256 orderId = latestOrderId() + 1;
+        setLatestOrderId(orderId);
+        setOrder(orderId, msg.sender, _token, _amount, _price, _isBuy, _agent, false);
 
         // 更新処理：売り注文の場合、預かりを拘束
         if (!_isBuy) {
-            balances[msg.sender][_token] = balances[msg.sender][_token].sub(_amount);
-            commitments[msg.sender][_token] = commitments[msg.sender][_token].add(_amount);
+            setBalance(msg.sender, _token, balanceOf(msg.sender, _token).sub(_amount));
+            setCommitment(msg.sender, _token, commitmentOf(msg.sender, _token).add(_amount));
         }
 
         // イベント登録：新規注文
@@ -174,14 +289,19 @@ contract IbetStraightBondExchange is Ownable {
         return true;
     }
 
-    // ファンクション：（投資家）注文をキャンセルする
-    function cancelOrder(uint256 _orderId) public returns (bool) {
+    // Function：（投資家）注文をキャンセルする
+    function cancelOrder(uint256 _orderId)
+        public
+        returns (bool)
+    {
         // <CHK>
         //  指定した注文番号が、直近の注文ID以上の場合
         //   -> REVERT
-        require(_orderId < latestOrderId);
+        require(_orderId <= latestOrderId());
 
-        Order storage order = orderBook[_orderId];
+        Order memory order;
+        (order.owner, order.token, order.amount, order.price, order.isBuy, order.agent, order.canceled) =
+            getOrder(_orderId);
 
         // <CHK>
         //  1) 元注文の残注文数量が0の場合
@@ -196,13 +316,12 @@ contract IbetStraightBondExchange is Ownable {
 
         // 更新処理：売り注文の場合、注文で拘束している預かりを解放 => 残高を投資家のアカウントに戻す
         if (!order.isBuy) {
-            commitments[msg.sender][order.token] =
-                commitments[msg.sender][order.token].sub(order.amount);
+            setCommitment(msg.sender, order.token, commitmentOf(msg.sender, order.token).sub(order.amount));
             IbetStraightBond(order.token).transfer(msg.sender,order.amount);
         }
 
         // 更新処理：キャンセル済みフラグをキャンセル済み（True）に更新
-        order.canceled = true;
+        setOrder(_orderId, order.owner, order.token, order.amount, order.price, order.isBuy, order.agent, true);
 
         // イベント登録：注文キャンセル
         emit CancelOrder(order.token, _orderId, msg.sender,
@@ -211,16 +330,19 @@ contract IbetStraightBondExchange is Ownable {
         return true;
     }
 
-    // ファンクション：（投資家）注文に応じる　Take注文 -> 約定
+    // Function：（投資家）注文に応じる　Take注文 -> 約定
     function executeOrder(uint256 _orderId, uint256 _amount, bool _isBuy)
         public
         returns (bool)
     {
         // <CHK>
         //  指定した注文IDが直近の注文IDを超えている場合
-        require(_orderId < latestOrderId);
+        require(_orderId <= latestOrderId());
 
-        Order storage order = orderBook[_orderId];
+        Order memory order;
+        (order.owner, order.token, order.amount, order.price, order.isBuy, order.agent, order.canceled) =
+            getOrder(_orderId);
+
         require(order.owner != 0x0000000000000000000000000000000000000000);
 
         if (_isBuy == true) { // 買注文の場合
@@ -270,47 +392,45 @@ contract IbetStraightBondExchange is Ownable {
                 PersonalInfo(personalInfoAddress).isRegistered(
                     msg.sender,IbetStraightBond(order.token).owner()) == false ||
                 IbetStraightBond(order.token).isRedeemed() == true ||
-                balances[msg.sender][order.token] < _amount ||
+                balanceOf(msg.sender, order.token) < _amount ||
                 order.amount < _amount )
             {
-                IbetStraightBond(order.token).transfer(msg.sender,
-                    balances[msg.sender][order.token]);
-                balances[msg.sender][order.token] = 0;
+                IbetStraightBond(order.token).transfer(msg.sender, balanceOf(msg.sender, order.token));
+                setBalance(msg.sender, order.token, 0);
                 return false;
             }
         }
 
         // 更新処理：約定IDをカウントアップ => 約定情報を挿入する
-        uint256 latestAgreementId = latestAgreementIds[_orderId]++;
-        uint256 _expiry = now + lockingPeriod;
-        agreements[_orderId][latestAgreementId] =
-            Agreement(msg.sender, _amount, order.price, false, false, _expiry);
+        uint256 agreementId = latestAgreementId(_orderId) + 1;
+        setLatestAgreementId(_orderId, agreementId);
+        uint256 expiry = now + lockingPeriod;
+        setAgreement(_orderId, agreementId, msg.sender, _amount, order.price, false, false, expiry);
 
         // 更新処理：元注文の数量を減らす
-        order.amount = order.amount.sub(_amount);
+        setOrder(_orderId, order.owner, order.token, order.amount.sub(_amount),
+            order.price, order.isBuy, order.agent, order.canceled);
 
         if (order.isBuy) {
             // 更新処理：買い注文に対して売り注文で応じた場合、売りの預かりを拘束
-            balances[msg.sender][order.token] =
-                balances[msg.sender][order.token].sub(_amount);
-            commitments[msg.sender][order.token] =
-                commitments[msg.sender][order.token].add(_amount);
+            setBalance(msg.sender, order.token, balanceOf(msg.sender, order.token).sub(_amount));
+            setCommitment(msg.sender, order.token, commitmentOf(msg.sender, order.token).add(_amount));
             // イベント登録：約定
-            emit Agree(order.token, _orderId, latestAgreementId, order.owner,
+            emit Agree(order.token, _orderId, agreementId, order.owner,
                 msg.sender, order.price, _amount, order.agent);
         } else {
             // イベント登録：約定
-            emit Agree(order.token, _orderId, latestAgreementId,
+            emit Agree(order.token, _orderId, agreementId,
                 msg.sender, order.owner, order.price, _amount, order.agent);
         }
 
         // 更新処理：現在値を更新する
-        lastPrice[order.token] = order.price;
+        setLastPrice(order.token, order.price);
 
         return true;
     }
 
-    // ファンクション：（決済業者）決済処理 -> 預かりの移動 -> 預かりの引き出し
+    // Function：（決済業者）決済処理 -> 預かりの移動 -> 預かりの引き出し
     function confirmAgreement(uint256 _orderId, uint256 _agreementId)
         public
         returns (bool)
@@ -319,11 +439,18 @@ contract IbetStraightBondExchange is Ownable {
         //  1) 指定した注文番号が、直近の注文ID以上の場合
         //  2) 指定した約定IDが、直近の約定ID以上の場合
         //   -> REVERT
-        require(_orderId < latestOrderId);
-        require(_agreementId < latestAgreementIds[_orderId]);
+        require(_orderId <= latestOrderId());
+        require(_agreementId <= latestAgreementId(_orderId));
 
-        Order storage order = orderBook[_orderId];
-        Agreement storage agreement = agreements[_orderId][_agreementId];
+        Order memory order;
+        (order.owner, order.token, order.amount, order.price, order.isBuy,
+            order.agent, order.canceled) =
+                getOrder(_orderId);
+
+        Agreement memory agreement;
+        (agreement.counterpart, agreement.amount, agreement.price,
+            agreement.canceled, agreement.paid, agreement.expiry) =
+                getAgreement(_orderId, _agreementId);
 
         // <CHK>
         //  1) すでに決済承認済み（支払い済み）の場合
@@ -337,12 +464,14 @@ contract IbetStraightBondExchange is Ownable {
         }
 
         // 更新処理：支払い済みフラグを支払い済み（True）に更新する
-        agreement.paid = true;
+        setAgreement(_orderId, _agreementId, agreement.counterpart, agreement.amount, agreement.price,
+            agreement.canceled, true, agreement.expiry);
 
         if (order.isBuy) {
             // 更新処理：買注文の場合、突合相手（売り手）から注文者（買い手）へと資産移転を行う
-            commitments[agreement.counterpart][order.token] =
-                commitments[agreement.counterpart][order.token].sub(agreement.amount);
+            setCommitment(
+                agreement.counterpart, order.token,
+                    commitmentOf(agreement.counterpart, order.token).sub(agreement.amount));
             IbetStraightBond(order.token).transfer(order.owner,agreement.amount);
             // イベント登録：決済OK
             emit SettlementOK(order.token, _orderId, _agreementId,
@@ -350,10 +479,10 @@ contract IbetStraightBondExchange is Ownable {
                 agreement.amount, order.agent);
         } else {
             // 更新処理：売注文の場合、注文者（売り手）から突合相手（買い手）へと資産移転を行う
-            commitments[order.owner][order.token] =
-                commitments[order.owner][order.token].sub(agreement.amount);
-            IbetStraightBond(order.token).transfer(agreement.counterpart,
-                                                  agreement.amount);
+            setCommitment(
+                order.owner, order.token,
+                    commitmentOf(order.owner, order.token).sub(agreement.amount));
+            IbetStraightBond(order.token).transfer(agreement.counterpart, agreement.amount);
             // イベント登録：決済OK
             emit SettlementOK(order.token, _orderId, _agreementId,
                 agreement.counterpart, order.owner, order.price,
@@ -363,7 +492,7 @@ contract IbetStraightBondExchange is Ownable {
         return true;
     }
 
-    // ファンクション：（決済業者）約定キャンセル
+    // Function：（決済業者）約定キャンセル
     function cancelAgreement(uint256 _orderId, uint256 _agreementId)
         public
         returns (bool)
@@ -372,11 +501,19 @@ contract IbetStraightBondExchange is Ownable {
         //  1) 指定した注文番号が、直近の注文ID以上の場合
         //  2) 指定した約定IDが、直近の約定ID以上の場合
         //   -> REVERT
-        require(_orderId < latestOrderId);
-        require(_agreementId < latestAgreementIds[_orderId]);
+        require(_orderId <= latestOrderId());
+        require(_agreementId <= latestAgreementId(_orderId));
 
-        Order storage order = orderBook[_orderId];
-        Agreement storage agreement = agreements[_orderId][_agreementId];
+
+        Order memory order;
+        (order.owner, order.token, order.amount, order.price, order.isBuy,
+            order.agent, order.canceled) =
+                getOrder(_orderId);
+
+        Agreement memory agreement;
+        (agreement.counterpart, agreement.amount, agreement.price,
+            agreement.canceled, agreement.paid, agreement.expiry) =
+                getAgreement(_orderId, _agreementId);
 
         if (agreement.expiry <= now) { // 約定明細の有効期限を超過している場合
           // <CHK>
@@ -409,15 +546,15 @@ contract IbetStraightBondExchange is Ownable {
         }
 
         // 更新処理：キャンセル済みフラグをキャンセル（True）に更新する
-        agreements[_orderId][_agreementId].canceled = true;
+        setAgreement(_orderId, _agreementId, agreement.counterpart, agreement.amount, agreement.price,
+            true, agreement.paid, agreement.expiry);
 
         if (order.isBuy) {
             // 更新処理：買い注文の場合、突合相手（売り手）の預かりを解放 -> 預かりの引き出し
             // 取り消した注文は無効化する（注文中状態に戻さない）
-            commitments[agreement.counterpart][order.token] =
-                commitments[agreement.counterpart][order.token].sub(agreement.amount);
-            IbetStraightBond(order.token).transfer(agreement.counterpart,
-                                                  agreement.amount);
+            setCommitment(agreement.counterpart, order.token,
+                commitmentOf(agreement.counterpart, order.token).sub(agreement.amount));
+            IbetStraightBond(order.token).transfer(agreement.counterpart, agreement.amount);
             // イベント登録：決済NG
             emit SettlementNG(order.token, _orderId, _agreementId,
                 order.owner, agreement.counterpart, order.price,
@@ -426,9 +563,9 @@ contract IbetStraightBondExchange is Ownable {
             // 更新処理：売り注文の場合、突合相手（買い手）の注文数量だけ注文者（売り手）の預かりを解放
             //  -> 預かりの引き出し。
             // 取り消した注文は無効化する（注文中状態に戻さない）
-            commitments[order.owner][order.token] =
-                commitments[order.owner][order.token].sub(agreement.amount);
-            IbetStraightBond(order.token).transfer(order.owner,agreement.amount);
+            setCommitment(order.owner, order.token,
+                commitmentOf(order.owner, order.token).sub(agreement.amount));
+            IbetStraightBond(order.token).transfer(order.owner, agreement.amount);
             // イベント登録：決済NG
             emit SettlementNG(order.token, _orderId, _agreementId,
                 agreement.counterpart, order.owner, order.price,
@@ -438,19 +575,23 @@ contract IbetStraightBondExchange is Ownable {
         return true;
     }
 
-    // ファンクション：（投資家）全ての預かりを引き出しする
+    // Function：（投資家）全ての預かりを引き出しする
     //  Note:
     //   未売却の預かり（balances）に対してのみ引き出しをおこなう。
     //   約定済、注文中の預かり（commitments）の引き出しはおこなわない。
-    function withdrawAll(address _token) public returns (bool) {
+    function withdrawAll(address _token)
+        public
+        returns (bool)
+    {
+        uint256 balance = balanceOf(msg.sender, _token);
 
         // <CHK>
         //  残高がゼロの場合、REVERT
-        if (balances[msg.sender][_token] == 0 ) { revert(); }
+        if (balance == 0 ) { revert(); }
 
         // 更新処理：トークン引き出し（送信）
-        IbetStraightBond(_token).transfer(msg.sender,balances[msg.sender][_token]);
-        balances[msg.sender][_token] = 0;
+        IbetStraightBond(_token).transfer(msg.sender, balance);
+        setBalance(msg.sender, _token, 0);
 
         // イベント登録
         emit Withdrawal(_token, msg.sender);
@@ -458,25 +599,25 @@ contract IbetStraightBondExchange is Ownable {
         return true;
     }
 
-    // ファンクション：トークンを送信する
+    // Function：トークンを送信する
     function transfer(address _token, address _to, uint256 _value)
         public
         returns (bool)
     {
+        uint256 balance = balanceOf(msg.sender, _token);
+
         // <CHK>
         //  1) 送信数量が0の場合
         //  2) 残高数量が送信数量に満たない場合
         //   -> 更新処理：全ての残高をsenderのアカウントに戻し、falseを返す
-        if (_value == 0 ||
-            balances[msg.sender][_token] < _value) {
-            IbetStraightBond(_token).transfer(msg.sender,
-                                              balances[msg.sender][_token]);
-            balances[msg.sender][_token] = 0;
+        if (_value == 0 || balance < _value) {
+            IbetStraightBond(_token).transfer(msg.sender, balance);
+            setBalance(msg.sender, _token, 0);
             return false;
         }
 
         // 更新処理：トークン送信
-        balances[msg.sender][_token] = balances[msg.sender][_token].sub(_value);
+        setBalance(msg.sender, _token, balance.sub(_value));
         IbetStraightBond(_token).transfer(_to, _value);
 
         // イベント登録
@@ -485,16 +626,18 @@ contract IbetStraightBondExchange is Ownable {
         return true;
     }
 
-    // ERC223 token deposit handler
-    function tokenFallback(address _from, uint _value, bytes /*_data*/) public{
-        balances[_from][msg.sender] = balances[_from][msg.sender].add(_value);
+    // Function： Deposit Handler
+    function tokenFallback(address _from, uint _value, bytes memory /*_data*/)
+        public
+    {
+        setBalance(_from, msg.sender, balanceOf(_from, msg.sender).add(_value));
     }
 
     // ファンクション：アドレスフォーマットがコントラクトのものかを判断する
     function isContract(address _addr)
-      private
-      view
-      returns (bool is_contract)
+        private
+        view
+        returns (bool is_contract)
     {
       uint length;
       assembly {

--- a/contracts/PaymentGateway.sol
+++ b/contracts/PaymentGateway.sol
@@ -82,7 +82,7 @@ contract PaymentGateway is Ownable {
     }
 
     // ファンクション：（収納代行業者）利用規約の追加
-    function addTerms(string _text) public returns (bool) {
+    function addTerms(string memory _text) public returns (bool) {
         uint16 version = latest_terms_version[msg.sender]++;
         Terms storage new_terms = terms[msg.sender][version];
         new_terms.text = _text;
@@ -114,7 +114,7 @@ contract PaymentGateway is Ownable {
 
     // ファンクション：支払情報を登録する
     //  ２回目以降は上書き登録を行う
-    function register(address _agent_address, string _encrypted_info)
+    function register(address _agent_address, string memory _encrypted_info)
         public
         returns (bool)
     {
@@ -149,7 +149,7 @@ contract PaymentGateway is Ownable {
     // ファンクション：（収納代行業者）口座情報を承認する
     function approve(address _account_address) public returns (bool) {
         PaymentAccount storage payment_account = payment_accounts[_account_address][msg.sender];
-        require(payment_account.account_address != 0);
+        require(payment_account.account_address != 0x0000000000000000000000000000000000000000);
 
         payment_account.approval_status = 2;
 
@@ -161,7 +161,7 @@ contract PaymentGateway is Ownable {
     // ファンクション：（収納代行業者）口座情報を警告状態にする
     function warn(address _account_address) public returns (bool) {
         PaymentAccount storage payment_account = payment_accounts[_account_address][msg.sender];
-        require(payment_account.account_address != 0);
+        require(payment_account.account_address != 0x0000000000000000000000000000000000000000);
 
         payment_account.approval_status = 3;
 
@@ -173,7 +173,7 @@ contract PaymentGateway is Ownable {
     // ファンクション：（収納代行業者）口座情報を非承認にする
     function unapprove(address _account_address) public returns (bool) {
         PaymentAccount storage payment_account = payment_accounts[_account_address][msg.sender];
-        require(payment_account.account_address != 0);
+        require(payment_account.account_address != 0x0000000000000000000000000000000000000000);
 
         payment_account.approval_status = 1;
 
@@ -185,7 +185,7 @@ contract PaymentGateway is Ownable {
     // ファンクション：（収納代行業者）口座情報をアカウント停止（BAN）する。
     function ban(address _account_address) public returns (bool) {
         PaymentAccount storage payment_account = payment_accounts[_account_address][msg.sender];
-        require(payment_account.account_address != 0);
+        require(payment_account.account_address != 0x0000000000000000000000000000000000000000);
 
         payment_account.approval_status = 4;
 
@@ -217,7 +217,9 @@ contract PaymentGateway is Ownable {
     {
         PaymentAccount storage payment_account = payment_accounts[_account_address][_agent_address];
         // アカウントが登録済み、かつ承認済みである場合、trueを返す
-        if (payment_account.account_address != 0 && payment_account.approval_status == 2) {
+        if (payment_account.account_address != 0x0000000000000000000000000000000000000000 &&
+            payment_account.approval_status == 2)
+        {
             return true;
         } else {
             return false;

--- a/contracts/PersonalInfo.sol
+++ b/contracts/PersonalInfo.sol
@@ -21,7 +21,7 @@ contract PersonalInfo {
     }
 
     // ファンクション：情報を登録する
-    function register(address _link_address, string _encrypted_info) public returns (bool) {
+    function register(address _link_address, string memory _encrypted_info) public returns (bool) {
         Info storage info = personal_info[msg.sender][_link_address];
 
         info.account_address = msg.sender;
@@ -36,7 +36,7 @@ contract PersonalInfo {
     // ファンクション：登録状況を確認する
     function isRegistered(address _account_address, address _link_address) public view returns (bool) {
         Info storage info = personal_info[_account_address][_link_address];
-        if (info.account_address == 0) {
+        if (info.account_address == 0x0000000000000000000000000000000000000000) {
             return false;
         } else {
             return true;

--- a/contracts/TokenList.sol
+++ b/contracts/TokenList.sol
@@ -17,8 +17,8 @@ contract TokenList is Ownable {
     event Register(address indexed token_address, string token_template,
         address owner_address);
 
-    function register(address _token_address, string _token_template) public {
-        require(tokens[_token_address].token_address == 0);
+    function register(address _token_address, string memory _token_template) public {
+        require(tokens[_token_address].token_address == 0x0000000000000000000000000000000000000000);
         require(IbetStandardTokenInterface(_token_address).owner() == msg.sender);
         tokens[_token_address].token_address = _token_address;
         tokens[_token_address].token_template = _token_template;
@@ -32,7 +32,7 @@ contract TokenList is Ownable {
     }
 
     function changeOwner(address _token_address, address _new_owner_address) public {
-        require(tokens[_token_address].token_address != 0);
+        require(tokens[_token_address].token_address != 0x0000000000000000000000000000000000000000);
         require(tokens[_token_address].owner_address == msg.sender);
         tokens[_token_address].owner_address = _new_owner_address;
         for (uint i = 0; i < token_list.length; i++) {
@@ -55,7 +55,7 @@ contract TokenList is Ownable {
         }
 
     function getTokenByNum(uint _num) public view
-        returns (address token_address, string token_template, address owner_address)
+        returns (address token_address, string memory token_template, address owner_address)
         {
             token_address = token_list[_num].token_address;
             token_template = token_list[_num].token_template;
@@ -63,7 +63,7 @@ contract TokenList is Ownable {
         }
 
     function getTokenByAddress(address _token_address) public view
-        returns (address token_address, string token_template, address owner_address)
+        returns (address token_address, string memory token_template, address owner_address)
         {
             token_address = tokens[_token_address].token_address;
             token_template = tokens[_token_address].token_template;

--- a/scripts/contract_deploy.py
+++ b/scripts/contract_deploy.py
@@ -15,38 +15,69 @@ with project.get_chain(chain_env) as chain:
     web3.personal.unlockAccount(web3.eth.defaultAccount, os.environ.get('ETH_ACCOUNT_PASSWORD'), 1000)
 
     # TokenList
-    token_list, _ = chain.provider.get_or_deploy_contract('TokenList')
+    token_list, _ = chain.provider.deploy_contract('TokenList')
 
     # PersonalInfo
-    personal_info, _ = chain.provider.get_or_deploy_contract('PersonalInfo')
+    personal_info, _ = chain.provider.deploy_contract('PersonalInfo')
 
     # PaymentGateway
-    payment_gateway, _ = chain.provider.get_or_deploy_contract('PaymentGateway')
+    payment_gateway, _ = chain.provider.deploy_contract('PaymentGateway')
+
+    # ------------------------------------
+    # IbetStraightBond
+    # ------------------------------------
+    # Storage
+    bond_exchange_storage, _ = chain.provider.deploy_contract('ExchangeStorage')
 
     # IbetStraightBondExchange
-    deploy_args = [payment_gateway.address, personal_info.address]
-    bond_exchange, _ = chain.provider.get_or_deploy_contract(
+    deploy_args = [
+        payment_gateway.address,
+        personal_info.address,
+        bond_exchange_storage.address
+    ]
+    bond_exchange, _ = chain.provider.deploy_contract(
         'IbetStraightBondExchange',
-        deploy_args = deploy_args
+        deploy_args=deploy_args
     )
+
+    # ------------------------------------
+    # IbetCoupon
+    # ------------------------------------
+    # Storage
+    coupon_exchange_storage, _ = chain.provider.deploy_contract('ExchangeStorage')
 
     # IbetCouponExchange
-    deploy_args = [payment_gateway.address]
-    coupon_exchange, _ = chain.provider.get_or_deploy_contract(
+    deploy_args = [
+        payment_gateway.address,
+        coupon_exchange_storage.address
+    ]
+    coupon_exchange, _ = chain.provider.deploy_contract(
         'IbetCouponExchange',
-        deploy_args = deploy_args
+        deploy_args=deploy_args
     )
 
+    # ------------------------------------
+    # IbetMembership
+    # ------------------------------------
+    # Storage
+    membership_exchange_storage, _ = chain.provider.deploy_contract('ExchangeStorage')
+
     # IbetMembershipExchange
-    deploy_args = [payment_gateway.address]
-    membership_exchange, _ = chain.provider.get_or_deploy_contract(
+    deploy_args = [
+        payment_gateway.address,
+        membership_exchange_storage.address
+    ]
+    membership_exchange, _ = chain.provider.deploy_contract(
         'IbetMembershipExchange',
-        deploy_args = deploy_args
+        deploy_args=deploy_args
     )
 
     print('TokenList : ' + token_list.address)
     print('PersonalInfo : ' + personal_info.address)
     print('PaymentGateway : ' + payment_gateway.address)
+    print('ExchangeStorage - Bond : ' + bond_exchange_storage.address)
     print('IbetStraightBondExchange : ' + bond_exchange.address)
+    print('ExchangeStorage - Coupon : ' + coupon_exchange_storage.address)
     print('IbetCouponExchange : ' + coupon_exchange.address)
+    print('ExchangeStorage - Membership : ' + membership_exchange_storage.address)
     print('IbetMembershipExchange : ' + membership_exchange.address)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,17 @@
 import pytest
 import os
 
+
 @pytest.yield_fixture()
 def chain(project):
-    APP_ENV = os.environ.get('APP_ENV') or 'local'
-    if APP_ENV == 'local':
+    app_env = os.environ.get('APP_ENV') or 'local'
+    if app_env == 'local':
         with project.get_chain('local_chain') as chain:
             yield chain
     else:
         with project.get_chain('dev_chain') as chain:
             yield chain
+
 
 @pytest.yield_fixture()
 def users(web3, accounts):
@@ -17,10 +19,10 @@ def users(web3, accounts):
     trader = accounts[1]
     issuer = accounts[2]
     agent = accounts[3]
-    web3.personal.unlockAccount(accounts[0],"password",0)
-    web3.personal.unlockAccount(accounts[1],"password",0)
-    web3.personal.unlockAccount(accounts[2],"password",0)
-    web3.personal.unlockAccount(accounts[3],"password",0)
+    web3.personal.unlockAccount(accounts[0], "password", 0)
+    web3.personal.unlockAccount(accounts[1], "password", 0)
+    web3.personal.unlockAccount(accounts[2], "password", 0)
+    web3.personal.unlockAccount(accounts[3], "password", 0)
     users = {
         'admin': admin,
         'trader': trader,
@@ -29,46 +31,78 @@ def users(web3, accounts):
     }
     return users
 
+
 @pytest.yield_fixture()
 def personal_info(web3, chain, users):
     web3.eth.defaultAccount = users['admin']
     personal_info, _ = chain.provider.get_or_deploy_contract('PersonalInfo')
     return personal_info
 
+
 @pytest.yield_fixture()
 def payment_gateway(web3, chain, users):
     web3.eth.defaultAccount = users['admin']
     payment_gateway, _ = chain.provider.get_or_deploy_contract('PaymentGateway')
-    txn_hash = payment_gateway.transact().addAgent(0, users['agent'])
-    chain.wait.for_receipt(txn_hash)
+    payment_gateway.transact().addAgent(0, users['agent'])
     return payment_gateway
 
+
 @pytest.yield_fixture()
-def bond_exchange(web3, chain, users, personal_info, payment_gateway):
+def bond_exchange_storage(web3, chain, users):
     web3.eth.defaultAccount = users['admin']
-    deploy_args = [payment_gateway.address, personal_info.address]
+    bond_exchange_storage, _ = chain.provider.get_or_deploy_contract('ExchangeStorage')
+    return bond_exchange_storage
+
+
+@pytest.yield_fixture()
+def bond_exchange(web3, chain, users, personal_info, payment_gateway, bond_exchange_storage):
+    web3.eth.defaultAccount = users['admin']
+    deploy_args = [
+        payment_gateway.address,
+        personal_info.address,
+        bond_exchange_storage.address
+    ]
     bond_exchange, _ = chain.provider.get_or_deploy_contract(
         'IbetStraightBondExchange',
-        deploy_args = deploy_args
+        deploy_args=deploy_args
     )
+    bond_exchange_storage.transact().upgradeVersion(bond_exchange.address)
     return bond_exchange
 
-@pytest.yield_fixture()
-def membership_exchange(web3, chain, users, payment_gateway):
-    web3.eth.defaultAccount = users['admin']
-    deploy_args = [payment_gateway.address]
-    membership_exchange, _ = chain.provider.get_or_deploy_contract(
-        'IbetMembershipExchange',
-        deploy_args = deploy_args
-    )
-    return membership_exchange
 
 @pytest.yield_fixture()
-def coupon_exchange(web3, chain, users, payment_gateway):
+def membership_exchange_storage(web3, chain, users):
     web3.eth.defaultAccount = users['admin']
-    deploy_args = [payment_gateway.address]
+    membership_exchange_storage, _ = chain.provider.get_or_deploy_contract('ExchangeStorage')
+    return membership_exchange_storage
+
+
+@pytest.yield_fixture()
+def membership_exchange(web3, chain, users, payment_gateway, membership_exchange_storage):
+    web3.eth.defaultAccount = users['admin']
+    deploy_args = [payment_gateway.address, membership_exchange_storage.address]
+    membership_exchange, _ = chain.provider.get_or_deploy_contract(
+        'IbetMembershipExchange',
+        deploy_args=deploy_args
+    )
+    membership_exchange_storage.transact().upgradeVersion(membership_exchange.address)
+    return membership_exchange
+
+
+@pytest.yield_fixture()
+def coupon_exchange_storage(web3, chain, users):
+    web3.eth.defaultAccount = users['admin']
+    coupon_exchange_storage, _ = chain.provider.get_or_deploy_contract('ExchangeStorage')
+    return coupon_exchange_storage
+
+
+@pytest.yield_fixture()
+def coupon_exchange(web3, chain, users, payment_gateway, coupon_exchange_storage):
+    web3.eth.defaultAccount = users['admin']
+    deploy_args = [payment_gateway.address, coupon_exchange_storage.address]
     coupon_exchange, _ = chain.provider.get_or_deploy_contract(
         'IbetCouponExchange',
-        deploy_args = deploy_args
+        deploy_args=deploy_args
     )
+    coupon_exchange_storage.transact().upgradeVersion(coupon_exchange.address)
     return coupon_exchange

--- a/tests/test_ibetcoupon.py
+++ b/tests/test_ibetcoupon.py
@@ -4,6 +4,8 @@ from eth_utils import to_checksum_address
 '''
 TEST1_デプロイ
 '''
+
+
 def init_args(exchange_address):
     name = 'test_coupon'
     symbol = 'CPN'
@@ -22,12 +24,14 @@ def init_args(exchange_address):
     ]
     return deploy_args
 
+
 def deploy(chain, deploy_args):
     coupon_contract, _ = chain.provider.get_or_deploy_contract(
         'IbetCoupon',
-        deploy_args = deploy_args
+        deploy_args=deploy_args
     )
     return coupon_contract
+
 
 # 正常系1: deploy
 def test_deploy_normal_1(web3, chain, users, coupon_exchange):
@@ -46,7 +50,7 @@ def test_deploy_normal_1(web3, chain, users, coupon_exchange):
     details = coupon.call().details()
     return_details = coupon.call().returnDetails()
     memo = coupon.call().memo()
-    expirationDate = coupon.call().expirationDate()
+    expiration_date = coupon.call().expirationDate()
     is_valid = coupon.call().status()
     transferable = coupon.call().transferable()
 
@@ -58,9 +62,10 @@ def test_deploy_normal_1(web3, chain, users, coupon_exchange):
     assert details == deploy_args[4]
     assert return_details == deploy_args[5]
     assert memo == deploy_args[6]
-    assert expirationDate == deploy_args[7]
-    assert is_valid == True
+    assert expiration_date == deploy_args[7]
+    assert is_valid is True
     assert transferable == deploy_args[8]
+
 
 # エラー系1: 入力値の型誤り（name）
 def test_deploy_error_1(chain, coupon_exchange):
@@ -69,7 +74,8 @@ def test_deploy_error_1(chain, coupon_exchange):
 
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
-            'IbetCoupon', deploy_args = deploy_args)
+            'IbetCoupon', deploy_args=deploy_args)
+
 
 # エラー系2: 入力値の型誤り（symbol）
 def test_deploy_error_2(chain, coupon_exchange):
@@ -78,7 +84,8 @@ def test_deploy_error_2(chain, coupon_exchange):
 
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
-            'IbetCoupon', deploy_args = deploy_args)
+            'IbetCoupon', deploy_args=deploy_args)
+
 
 # エラー系3: 入力値の型誤り（totalSupply）
 def test_deploy_error_3(chain, coupon_exchange):
@@ -87,7 +94,8 @@ def test_deploy_error_3(chain, coupon_exchange):
 
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
-            'IbetCoupon', deploy_args = deploy_args)
+            'IbetCoupon', deploy_args=deploy_args)
+
 
 # エラー系4: 入力値の型誤り（tradableExchange）
 def test_deploy_error_4(chain, coupon_exchange):
@@ -96,7 +104,8 @@ def test_deploy_error_4(chain, coupon_exchange):
 
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
-            'IbetCoupon', deploy_args = deploy_args)
+            'IbetCoupon', deploy_args=deploy_args)
+
 
 # エラー系5: 入力値の型誤り（details）
 def test_deploy_error_5(chain, coupon_exchange):
@@ -105,7 +114,8 @@ def test_deploy_error_5(chain, coupon_exchange):
 
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
-            'IbetCoupon', deploy_args = deploy_args)
+            'IbetCoupon', deploy_args=deploy_args)
+
 
 # エラー系6: 入力値の型誤り（returnDetails）
 def test_deploy_error_6(chain, coupon_exchange):
@@ -114,7 +124,8 @@ def test_deploy_error_6(chain, coupon_exchange):
 
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
-            'IbetCoupon', deploy_args = deploy_args)
+            'IbetCoupon', deploy_args=deploy_args)
+
 
 # エラー系7: 入力値の型誤り（memo）
 def test_deploy_error_7(chain, coupon_exchange):
@@ -123,7 +134,8 @@ def test_deploy_error_7(chain, coupon_exchange):
 
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
-            'IbetCoupon', deploy_args = deploy_args)
+            'IbetCoupon', deploy_args=deploy_args)
+
 
 # エラー系8: 入力値の型誤り（expirationDate）
 def test_deploy_error_8(chain, coupon_exchange):
@@ -132,7 +144,8 @@ def test_deploy_error_8(chain, coupon_exchange):
 
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
-            'IbetCoupon', deploy_args = deploy_args)
+            'IbetCoupon', deploy_args=deploy_args)
+
 
 # エラー系9: 入力値の型誤り（transferable）
 def test_deploy_error_9(chain, coupon_exchange):
@@ -141,11 +154,14 @@ def test_deploy_error_9(chain, coupon_exchange):
 
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
-            'IbetCoupon', deploy_args = deploy_args)
+            'IbetCoupon', deploy_args=deploy_args)
+
 
 '''
 TEST2_クーポンの割当（allocate）
 '''
+
+
 # 正常系1: アカウントアドレスへの割当
 def test_allocate_normal_1(web3, chain, users, coupon_exchange):
     _from = users['issuer']
@@ -167,6 +183,7 @@ def test_allocate_normal_1(web3, chain, users, coupon_exchange):
     assert from_balance == deploy_args[2] - _value
     assert to_balance == _value
 
+
 # 正常系2-1: Exchangeを経由しての割当（譲渡可能クーポン）
 def test_allocate_normal_2_1(web3, chain, users, coupon_exchange):
     _from = users['issuer']
@@ -183,7 +200,7 @@ def test_allocate_normal_2_1(web3, chain, users, coupon_exchange):
     chain.wait.for_receipt(txn_hash)
 
     # 割当（ExchangeからToアドレスへ）
-    txn_hash = coupon_exchange.transact().\
+    txn_hash = coupon_exchange.transact(). \
         transfer(coupon.address, _to, _value)
     chain.wait.for_receipt(txn_hash)
 
@@ -192,6 +209,7 @@ def test_allocate_normal_2_1(web3, chain, users, coupon_exchange):
 
     assert from_balance == deploy_args[2] - _value
     assert to_balance == _value
+
 
 # 正常系2-2: Exchangeを経由しての割当（譲渡不可クーポン）
 def test_allocate_normal_2_2(web3, chain, users, coupon_exchange):
@@ -202,7 +220,7 @@ def test_allocate_normal_2_2(web3, chain, users, coupon_exchange):
     # 新規発行
     web3.eth.defaultAccount = _from
     deploy_args = init_args(coupon_exchange.address)
-    deploy_args[8] = False # 譲渡不可
+    deploy_args[8] = False  # 譲渡不可
     coupon = deploy(chain, deploy_args)
 
     # 割当（Exchangeへ）
@@ -210,7 +228,7 @@ def test_allocate_normal_2_2(web3, chain, users, coupon_exchange):
     chain.wait.for_receipt(txn_hash)
 
     # 割当（ExchangeからToアドレスへ）
-    txn_hash = coupon_exchange.transact().\
+    txn_hash = coupon_exchange.transact(). \
         transfer(coupon.address, _to, _value)
     chain.wait.for_receipt(txn_hash)
 
@@ -219,6 +237,7 @@ def test_allocate_normal_2_2(web3, chain, users, coupon_exchange):
 
     assert from_balance == deploy_args[2] - _value
     assert to_balance == _value
+
 
 # エラー系1: 入力値の型誤り（To）
 def test_allocate_error_1(web3, chain, users, coupon_exchange):
@@ -235,6 +254,7 @@ def test_allocate_error_1(web3, chain, users, coupon_exchange):
     with pytest.raises(TypeError):
         coupon.transact().transfer(_to, _value)
 
+
 # エラー系2: 入力値の型誤り（Value）
 def test_allocate_error_2(web3, chain, users, coupon_exchange):
     _from = users['issuer']
@@ -250,13 +270,14 @@ def test_allocate_error_2(web3, chain, users, coupon_exchange):
         coupon.transact().transfer(_to, '0')
 
     with pytest.raises(TypeError):
-        coupon.transact().transfer(_to, 2**256)
+        coupon.transact().transfer(_to, 2 ** 256)
 
     with pytest.raises(TypeError):
         coupon.transact().transfer(_to, -1)
 
     with pytest.raises(TypeError):
         coupon.transact().transfer(_to, 0.1)
+
 
 # エラー系3: 残高不足
 def test_allocate_error_3(web3, chain, users, coupon_exchange):
@@ -271,11 +292,12 @@ def test_allocate_error_3(web3, chain, users, coupon_exchange):
     # 割当（残高超）
     web3.eth.defaultAccount = _from
     _value = deploy_args[2] + 1
-    txn_hash = coupon.transact().transfer(_to, _value) #エラーになる
+    txn_hash = coupon.transact().transfer(_to, _value)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     assert coupon.call().balanceOf(_from) == deploy_args[2]
     assert coupon.call().balanceOf(_to) == 0
+
 
 # エラー系4: 権限なし
 def test_allocate_error_4(web3, chain, users, coupon_exchange):
@@ -290,15 +312,18 @@ def test_allocate_error_4(web3, chain, users, coupon_exchange):
     # 割当（権限なし）
     web3.eth.defaultAccount = _other
     _value = deploy_args[2]
-    txn_hash = coupon.transact().transfer(_other, _value) #エラーになる
+    txn_hash = coupon.transact().transfer(_other, _value)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     assert coupon.call().balanceOf(_issuer) == deploy_args[2]
     assert coupon.call().balanceOf(_other) == 0
 
+
 '''
 TEST3_クーポンの譲渡（transfer）
 '''
+
+
 # 正常系1: アカウントアドレスへの譲渡
 def test_transfer_normal_1(web3, chain, users, coupon_exchange):
     _from = users['issuer']
@@ -321,6 +346,7 @@ def test_transfer_normal_1(web3, chain, users, coupon_exchange):
     assert from_balance == deploy_args[2] - _value
     assert to_balance == _value
 
+
 # エラー系1: 入力値の型誤り（To）
 def test_transfer_error_1(web3, chain, users, coupon_exchange):
     _from = users['issuer']
@@ -336,6 +362,7 @@ def test_transfer_error_1(web3, chain, users, coupon_exchange):
     web3.eth.defaultAccount = _from
     with pytest.raises(TypeError):
         coupon.transact().transfer(_to, _value)
+
 
 # エラー系2: 入力値の型誤り（Value）
 def test_transfer_error_2(web3, chain, users, coupon_exchange):
@@ -353,13 +380,14 @@ def test_transfer_error_2(web3, chain, users, coupon_exchange):
         coupon.transact().transfer(_to, '0')
 
     with pytest.raises(TypeError):
-        coupon.transact().transfer(_to, 2**256)
+        coupon.transact().transfer(_to, 2 ** 256)
 
     with pytest.raises(TypeError):
         coupon.transact().transfer(_to, -1)
 
     with pytest.raises(TypeError):
         coupon.transact().transfer(_to, 0.1)
+
 
 # エラー系3: 残高不足
 def test_transfer_error_3(web3, chain, users, coupon_exchange):
@@ -374,11 +402,12 @@ def test_transfer_error_3(web3, chain, users, coupon_exchange):
     # 譲渡（残高超）
     web3.eth.defaultAccount = _from
     _value = deploy_args[2] + 1
-    txn_hash = coupon.transact().transfer(_to, _value) # エラーになる
+    txn_hash = coupon.transact().transfer(_to, _value)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     assert coupon.call().balanceOf(_from) == deploy_args[2]
     assert coupon.call().balanceOf(_to) == 0
+
 
 # エラー系4: 譲渡不可クーポンの譲渡
 def test_transfer_error_4(web3, chain, users, coupon_exchange):
@@ -394,14 +423,16 @@ def test_transfer_error_4(web3, chain, users, coupon_exchange):
     # 譲渡（譲渡不可）
     web3.eth.defaultAccount = _from
     _value = 1
-    txn_hash = coupon.transact().transfer(_to, _value) # エラーになる
+    txn_hash = coupon.transact().transfer(_to, _value)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     assert coupon.call().balanceOf(_from) == deploy_args[2]
     assert coupon.call().balanceOf(_to) == 0
 
+
 # エラー系5: 取引不可Exchangeへの振替
-def test_transfer_error_5(web3, chain, users, coupon_exchange, payment_gateway):
+def test_transfer_error_5(web3, chain, users, coupon_exchange, coupon_exchange_storage,
+                          payment_gateway):
     _issuer = users['issuer']
 
     # 新規発行
@@ -412,22 +443,25 @@ def test_transfer_error_5(web3, chain, users, coupon_exchange, payment_gateway):
     # 取引不可Exchange
     web3.eth.defaultAccount = users['admin']
     dummy_exchange, _ = chain.provider.get_or_deploy_contract(
-        'IbetMembershipExchange', # IbetCouponExchange以外を読み込む必要がある
-        deploy_args = [payment_gateway.address]
+        'IbetMembershipExchange',  # IbetCouponExchange以外を読み込む必要がある
+        deploy_args=[payment_gateway.address, coupon_exchange_storage.address]
     )
 
     # 譲渡
     web3.eth.defaultAccount = _issuer
     _value = deploy_args[2]
-    txn_hash = coupon.transact().transfer(dummy_exchange.address, _value) #エラーになる
+    txn_hash = coupon.transact().transfer(dummy_exchange.address, _value)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     assert coupon.call().balanceOf(_issuer) == deploy_args[2]
     assert coupon.call().balanceOf(dummy_exchange.address) == 0
 
+
 '''
 TEST4_クーポンの消費（consume）
 '''
+
+
 # 正常系1
 # ＜発行者＞発行　->　＜発行者＞消費
 def test_consume_normal_1(web3, chain, users, coupon_exchange):
@@ -449,6 +483,7 @@ def test_consume_normal_1(web3, chain, users, coupon_exchange):
 
     assert balance == deploy_args[2] - _value
     assert used == _value
+
 
 # 正常系2
 # ＜発行者＞発行　->　＜発行者＞割当　-> ＜消費者＞消費
@@ -480,6 +515,7 @@ def test_consume_normal_2(web3, chain, users, coupon_exchange):
     assert balance_consumer == 0
     assert used_consumer == _value
 
+
 # エラー系1: 入力値の型誤り（Value）
 def test_consume_error_1(web3, chain, users, coupon_exchange):
     _issuer = users['issuer']
@@ -497,13 +533,14 @@ def test_consume_error_1(web3, chain, users, coupon_exchange):
         coupon.transact().consume('0')
 
     with pytest.raises(TypeError):
-        coupon.transact().consume(2**256)
+        coupon.transact().consume(2 ** 256)
 
     with pytest.raises(TypeError):
         coupon.transact().consume(-1)
 
     with pytest.raises(TypeError):
         coupon.transact().consume(0.1)
+
 
 # エラー系2: 残高不足
 def test_consume_error_2(web3, chain, users, coupon_exchange):
@@ -517,11 +554,12 @@ def test_consume_error_2(web3, chain, users, coupon_exchange):
     # 消費
     web3.eth.defaultAccount = _issuer
     _value = deploy_args[2] + 1
-    txn_hash = coupon.transact().consume(_value) # エラーになる
+    txn_hash = coupon.transact().consume(_value)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     assert coupon.call().balanceOf(_issuer) == deploy_args[2]
     assert coupon.call().usedOf(_issuer) == 0
+
 
 # エラー系3: 無効化されたクーポンの消費
 def test_consume_error_3(web3, chain, users, coupon_exchange):
@@ -540,15 +578,18 @@ def test_consume_error_3(web3, chain, users, coupon_exchange):
 
     # 消費
     web3.eth.defaultAccount = _issuer
-    txn_hash = coupon.transact().consume(_value) #エラーになる
+    txn_hash = coupon.transact().consume(_value)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     assert coupon.call().balanceOf(_issuer) == deploy_args[2]
     assert coupon.call().usedOf(_issuer) == 0
 
+
 '''
 TEST5_追加発行（issue）
 '''
+
+
 # 正常系1
 # ＜発行者＞発行　->　＜発行者＞追加発行
 def test_issue_normal_1(web3, chain, users, coupon_exchange):
@@ -566,10 +607,11 @@ def test_issue_normal_1(web3, chain, users, coupon_exchange):
     chain.wait.for_receipt(txn_hash)
 
     balance = coupon.call().balanceOf(_issuer)
-    totalSupply = coupon.call().totalSupply()
+    total_supply = coupon.call().totalSupply()
 
     assert balance == deploy_args[2] + _value
-    assert totalSupply == deploy_args[2] + _value
+    assert total_supply == deploy_args[2] + _value
+
 
 # 正常系2
 # ＜発行者＞発行　->　＜発行者＞割当 -> ＜発行者＞追加発行
@@ -594,10 +636,11 @@ def test_issue_normal_2(web3, chain, users, coupon_exchange):
     chain.wait.for_receipt(txn_hash)
 
     balance = coupon.call().balanceOf(_issuer)
-    totalSupply = coupon.call().totalSupply()
+    total_supply = coupon.call().totalSupply()
 
     assert balance == deploy_args[2] + _value - _allocated
-    assert totalSupply == deploy_args[2] + _value
+    assert total_supply == deploy_args[2] + _value
+
 
 # エラー系1: 入力値の型誤り（Value）
 def test_issue_error_1(web3, chain, users, coupon_exchange):
@@ -614,7 +657,7 @@ def test_issue_error_1(web3, chain, users, coupon_exchange):
         coupon.transact().issue('0')
 
     with pytest.raises(TypeError):
-        coupon.transact().issue(2**256)
+        coupon.transact().issue(2 ** 256)
 
     with pytest.raises(TypeError):
         coupon.transact().issue(-1)
@@ -622,13 +665,14 @@ def test_issue_error_1(web3, chain, users, coupon_exchange):
     with pytest.raises(TypeError):
         coupon.transact().issue(0.1)
 
+
 # エラー系2
 # ＜発行者＞発行　->　＜発行者＞追加発行（uint最大値超）
 def test_issue_error_2(web3, chain, users, coupon_exchange):
     _issuer = users['issuer']
     _consumer = users['trader']
     _allocated = 999999
-    _value = 2**256 - 1
+    _value = 2 ** 256 - 1
 
     # 新規発行
     web3.eth.defaultAccount = _issuer
@@ -641,14 +685,15 @@ def test_issue_error_2(web3, chain, users, coupon_exchange):
 
     # 追加発行（uint最大値超）
     web3.eth.defaultAccount = _issuer
-    txn_hash = coupon.transact().issue(_value) # エラーになる（2**256 -1 +1）
+    txn_hash = coupon.transact().issue(_value)  # エラーになる（2**256 -1 +1）
     chain.wait.for_receipt(txn_hash)
 
     balance = coupon.call().balanceOf(_issuer)
-    totalSupply = coupon.call().totalSupply()
+    total_supply = coupon.call().totalSupply()
 
     assert balance == deploy_args[2] - _allocated
-    assert totalSupply == deploy_args[2]
+    assert total_supply == deploy_args[2]
+
 
 # エラー系3
 # ＜発行者＞発行　->　＜発行者以外＞追加発行
@@ -664,18 +709,21 @@ def test_issue_error_3(web3, chain, users, coupon_exchange):
 
     # 追加発行（uint最大値超）
     web3.eth.defaultAccount = _other
-    txn_hash = coupon.transact().issue(_value) # エラーになる
+    txn_hash = coupon.transact().issue(_value)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     balance = coupon.call().balanceOf(_issuer)
-    totalSupply = coupon.call().totalSupply()
+    total_supply = coupon.call().totalSupply()
 
     assert balance == deploy_args[2]
-    assert totalSupply == deploy_args[2]
+    assert total_supply == deploy_args[2]
+
 
 '''
 TEST6_クーポン詳細欄の更新（setDetails）
 '''
+
+
 # 正常系1
 # ＜発行者＞発行 -> ＜発行者＞詳細欄の修正
 def test_setDetails_normal_1(web3, chain, users, coupon_exchange):
@@ -694,6 +742,7 @@ def test_setDetails_normal_1(web3, chain, users, coupon_exchange):
     details = coupon.call().details()
     assert details == 'updated details'
 
+
 # エラー系1: 入力値の型誤り
 def test_setDetails_error_1(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -707,6 +756,7 @@ def test_setDetails_error_1(web3, chain, users, coupon_exchange):
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
         coupon.transact().setDetails(1234)
+
 
 # エラー系2: 権限エラー
 def test_setDetails_error_2(web3, chain, users, coupon_exchange):
@@ -726,9 +776,12 @@ def test_setDetails_error_2(web3, chain, users, coupon_exchange):
     details = coupon.call().details()
     assert details == 'some_details'
 
+
 '''
 TEST7_メモ欄の更新（setMemo）
 '''
+
+
 # 正常系1
 # ＜発行者＞発行 -> ＜発行者＞メモ欄の修正
 def test_setMemo_normal_1(web3, chain, users, coupon_exchange):
@@ -747,6 +800,7 @@ def test_setMemo_normal_1(web3, chain, users, coupon_exchange):
     details = coupon.call().memo()
     assert details == 'updated memo'
 
+
 # エラー系1: 入力値の型誤り
 def test_setMemo_error_1(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -760,6 +814,7 @@ def test_setMemo_error_1(web3, chain, users, coupon_exchange):
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
         coupon.transact().setMemo(1234)
+
 
 # エラー系2: 権限エラー
 def test_setMemo_error_2(web3, chain, users, coupon_exchange):
@@ -779,9 +834,12 @@ def test_setMemo_error_2(web3, chain, users, coupon_exchange):
     details = coupon.call().memo()
     assert details == 'some_memo'
 
+
 '''
 TEST8_残高確認（balanceOf）
 '''
+
+
 # 正常系1: クーポン新規作成 -> 残高確認
 def test_balanceOf_normal_1(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -793,6 +851,7 @@ def test_balanceOf_normal_1(web3, chain, users, coupon_exchange):
 
     balance = coupon.call().balanceOf(issuer)
     assert balance == deploy_args[2]
+
 
 # エラー系1: 入力値の型誤り（Owner）
 def test_balanceOf_error_1(web3, chain, users, coupon_exchange):
@@ -808,9 +867,12 @@ def test_balanceOf_error_1(web3, chain, users, coupon_exchange):
     with pytest.raises(TypeError):
         coupon.call().balanceOf(account_address)
 
+
 '''
 TEST9_使用済数量確認（usedOf）
 '''
+
+
 # 正常系1: クーポン作成 -> 消費 -> 使用済数量確認
 def test_usedOf_normal_1(web3, chain, users, coupon_exchange):
     _issuer = users['issuer']
@@ -831,6 +893,7 @@ def test_usedOf_normal_1(web3, chain, users, coupon_exchange):
 
     assert used == _value
 
+
 # エラー系1: 入力値の型誤り（Owner）
 def test_usedOf_error_1(web3, chain, users, coupon_exchange):
     _issuer = users['issuer']
@@ -845,9 +908,12 @@ def test_usedOf_error_1(web3, chain, users, coupon_exchange):
     with pytest.raises(TypeError):
         coupon.call().usedOf(account_address)
 
+
 '''
 TEST10_商品画像の設定（setImageURL, getImageURL）
 '''
+
+
 # 正常系1: 発行 -> 商品画像の設定
 def test_setImageURL_normal_1(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -865,6 +931,7 @@ def test_setImageURL_normal_1(web3, chain, users, coupon_exchange):
 
     image_url_0 = coupon.call().getImageURL(0)
     assert image_url_0 == image_url
+
 
 # 正常系2: 発行 -> 商品画像の設定（複数設定）
 def test_setImageURL_normal_2(web3, chain, users, coupon_exchange):
@@ -892,6 +959,7 @@ def test_setImageURL_normal_2(web3, chain, users, coupon_exchange):
     assert image_url_0 == image_url
     assert image_url_1 == image_url
 
+
 # 正常系3: 発行（デプロイ） -> 商品画像の設定（上書き登録）
 def test_setImageURL_normal_3(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -916,6 +984,7 @@ def test_setImageURL_normal_3(web3, chain, users, coupon_exchange):
 
     image_url_0 = coupon.call().getImageURL(0)
     assert image_url_0 == image_url_after
+
 
 # エラー系1: 入力値の型誤り（Class）
 def test_setImageURL_error_1(web3, chain, users, coupon_exchange):
@@ -948,6 +1017,7 @@ def test_setImageURL_error_1(web3, chain, users, coupon_exchange):
     with pytest.raises(TypeError):
         coupon.transact().getImageURL('0')
 
+
 # エラー系2: 入力値の型誤り（ImageURL）
 def test_setImageURL_error_2(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -963,6 +1033,7 @@ def test_setImageURL_error_2(web3, chain, users, coupon_exchange):
     with pytest.raises(TypeError):
         coupon.transact().setImageURL(0, image_url)
 
+
 # エラー系3: 権限エラー
 def test_setImageURL_error_3(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -977,15 +1048,18 @@ def test_setImageURL_error_3(web3, chain, users, coupon_exchange):
 
     # 画像設定
     web3.eth.defaultAccount = other
-    txn_hash = coupon.transact().setImageURL(0, image_url) # エラーになる
+    txn_hash = coupon.transact().setImageURL(0, image_url)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     image_url_0 = coupon.call().getImageURL(0)
     assert image_url_0 == ''
 
+
 '''
 TEST11_ステータス（有効・無効）の更新（setStatus）
 '''
+
+
 # 正常系1
 # ＜発行者＞発行 -> ＜発行者＞ステータスの修正
 def test_setStatus_normal_1(web3, chain, users, coupon_exchange):
@@ -1001,7 +1075,8 @@ def test_setStatus_normal_1(web3, chain, users, coupon_exchange):
     txn_hash = coupon.transact().setStatus(False)
     chain.wait.for_receipt(txn_hash)
 
-    assert coupon.call().status() == False
+    assert coupon.call().status() is False
+
 
 # エラー系1: 入力値の型誤り
 def test_setStatus_error_1(web3, chain, users, coupon_exchange):
@@ -1016,6 +1091,7 @@ def test_setStatus_error_1(web3, chain, users, coupon_exchange):
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
         coupon.transact().setStatus('False')
+
 
 # エラー系2: 権限エラー
 def test_setStatus_error_2(web3, chain, users, coupon_exchange):
@@ -1032,13 +1108,17 @@ def test_setStatus_error_2(web3, chain, users, coupon_exchange):
     txn_hash = coupon.transact().setStatus(False)
     chain.wait.for_receipt(txn_hash)
 
-    assert coupon.call().status() == True
+    assert coupon.call().status() is True
+
 
 '''
 TEST12_取引可能Exchangeの更新（setTradableExchange）
 '''
+
+
 # 正常系1: 発行 -> Exchangeの更新
-def test_setTradableExchange_normal_1(web3, chain, users, coupon_exchange, payment_gateway):
+def test_setTradableExchange_normal_1(web3, chain, users, coupon_exchange,
+                                      coupon_exchange_storage, payment_gateway):
     issuer = users['issuer']
 
     # 新規発行
@@ -1046,11 +1126,11 @@ def test_setTradableExchange_normal_1(web3, chain, users, coupon_exchange, payme
     deploy_args = init_args(coupon_exchange.address)
     coupon = deploy(chain, deploy_args)
 
-    # その他Exchange
+    # Exchange（新）
     web3.eth.defaultAccount = users['admin']
     other_exchange, _ = chain.provider.get_or_deploy_contract(
-        'IbetMembershipExchange', # IbetCouponExchange以外を読み込む必要がある
-        deploy_args = [payment_gateway.address]
+        'IbetMembershipExchange',  # IbetCouponExchange以外を読み込む必要がある
+        deploy_args=[payment_gateway.address, coupon_exchange_storage.address]
     )
 
     # Exchangeの更新
@@ -1058,8 +1138,8 @@ def test_setTradableExchange_normal_1(web3, chain, users, coupon_exchange, payme
     txn_hash = coupon.transact().setTradableExchange(other_exchange.address)
     chain.wait.for_receipt(txn_hash)
 
-    assert coupon.call().tradableExchange() == \
-        to_checksum_address(other_exchange.address)
+    assert coupon.call().tradableExchange() == to_checksum_address(other_exchange.address)
+
 
 # エラー系1: 発行 -> Exchangeの更新（入力値の型誤り）
 def test_setTradableExchange_error_1(web3, chain, users, coupon_exchange):
@@ -1075,6 +1155,7 @@ def test_setTradableExchange_error_1(web3, chain, users, coupon_exchange):
     with pytest.raises(TypeError):
         coupon.transact().setTradableExchange('0xaaaa')
 
+
 # エラー系2: 発行 -> Exchangeの更新（権限エラー）
 def test_setTradableExchange_error_2(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -1088,21 +1169,23 @@ def test_setTradableExchange_error_2(web3, chain, users, coupon_exchange):
     # その他Exchange
     web3.eth.defaultAccount = users['admin']
     other_exchange, _ = chain.provider.get_or_deploy_contract(
-        'IbetCouponExchange', # IbetCouponExchange以外を読み込む必要がある
-        deploy_args = []
+        'IbetCouponExchange',  # IbetCouponExchange以外を読み込む必要がある
+        deploy_args=[]
     )
 
     # Exchangeの更新
     web3.eth.defaultAccount = trader
-    txn_hash = coupon.transact().setTradableExchange(other_exchange.address) #エラーになる
+    txn_hash = coupon.transact().setTradableExchange(other_exchange.address)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
-    assert coupon.call().tradableExchange() == \
-        to_checksum_address(coupon_exchange.address)
+    assert coupon.call().tradableExchange() == to_checksum_address(coupon_exchange.address)
+
 
 '''
 TEST13_有効期限更新（setExpirationDate）
 '''
+
+
 # 正常系1: 発行 -> 有効期限更新
 def test_setExpirationDate_normal_1(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -1122,6 +1205,7 @@ def test_setExpirationDate_normal_1(web3, chain, users, coupon_exchange):
     expiration_date = coupon.call().expirationDate()
     assert after_expiration_date == expiration_date
 
+
 # エラー系1: 入力値の型誤り
 def test_setExpirationDate_errors_1(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -1135,6 +1219,7 @@ def test_setExpirationDate_errors_1(web3, chain, users, coupon_exchange):
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
         coupon.transact().setExpirationDate(1234)
+
 
 # エラー系2: 権限エラー
 def test_setExpirationDate_error_2(web3, chain, users, coupon_exchange):
@@ -1150,15 +1235,18 @@ def test_setExpirationDate_error_2(web3, chain, users, coupon_exchange):
     # 有効期限更新：権限エラー
     web3.eth.defaultAccount = attacker
     txn_hash = \
-        coupon.transact().setExpirationDate(after_expiration_date) # エラーになる
+        coupon.transact().setExpirationDate(after_expiration_date)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     expiration_date = coupon.call().expirationDate()
     assert expiration_date == deploy_args[7]
 
+
 '''
 TEST14_譲渡可能更新（setTransferable）
 '''
+
+
 # 正常系1: 発行 -> 譲渡可能更新
 def test_setTransferable_normal_1(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -1177,6 +1265,7 @@ def test_setTransferable_normal_1(web3, chain, users, coupon_exchange):
     transferable = coupon.call().transferable()
     assert after_transferable == transferable
 
+
 # エラー系1: 入力値の型誤り
 def test_setTransferable_error_1(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -1190,6 +1279,7 @@ def test_setTransferable_error_1(web3, chain, users, coupon_exchange):
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
         coupon.transact().setTransferable('True')
+
 
 # エラー系2: 権限エラー
 def test_setTransferable_error_2(web3, chain, users, coupon_exchange):
@@ -1205,15 +1295,18 @@ def test_setTransferable_error_2(web3, chain, users, coupon_exchange):
     # 譲渡可能更新
     web3.eth.defaultAccount = attacker
     txn_hash = \
-        coupon.transact().setTransferable(after_transferable) # エラーになる
+        coupon.transact().setTransferable(after_transferable)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     transferable = coupon.call().transferable()
     assert transferable == deploy_args[8]
 
+
 '''
 TEST15_新規募集ステータス更新（setInitialOfferingStatus）
 '''
+
+
 # 正常系1: 発行 -> 新規募集ステータス更新（False→True）
 def test_setInitialOfferingStatus_normal_1(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -1224,14 +1317,15 @@ def test_setInitialOfferingStatus_normal_1(web3, chain, users, coupon_exchange):
     coupon = deploy(chain, deploy_args)
 
     # 初期状態 == False
-    assert coupon.call().initialOfferingStatus() == False
+    assert coupon.call().initialOfferingStatus() is False
 
     # 新規募集ステータスの更新
     web3.eth.defaultAccount = issuer
     txn_hash = coupon.transact().setInitialOfferingStatus(True)
     chain.wait.for_receipt(txn_hash)
 
-    assert coupon.call().initialOfferingStatus() == True
+    assert coupon.call().initialOfferingStatus() is True
+
 
 # 正常系2:
 #   発行 -> 新規募集ステータス更新（False→True） -> 2回目更新（True→False）
@@ -1253,7 +1347,8 @@ def test_setInitialOfferingStatus_normal_2(web3, chain, users, coupon_exchange):
     txn_hash = coupon.transact().setInitialOfferingStatus(False)
     chain.wait.for_receipt(txn_hash)
 
-    assert coupon.call().initialOfferingStatus() == False
+    assert coupon.call().initialOfferingStatus() is False
+
 
 # エラー系1: 発行 -> 新規募集ステータス更新（入力値の型誤り）
 def test_setInitialOfferingStatus_error_1(web3, chain, users, coupon_exchange):
@@ -1269,9 +1364,12 @@ def test_setInitialOfferingStatus_error_1(web3, chain, users, coupon_exchange):
     with pytest.raises(TypeError):
         coupon.transact().setInitialOfferingStatus('True')
 
+
 '''
 TEST16_募集申込（applyForOffering）
 '''
+
+
 # 正常系1
 #   発行：発行体 -> 投資家：募集申込
 def test_applyForOffering_normal_1(web3, chain, users, coupon_exchange):
@@ -1295,6 +1393,7 @@ def test_applyForOffering_normal_1(web3, chain, users, coupon_exchange):
 
     assert coupon.call().applications(trader) == 'abcdefgh'
 
+
 # 正常系2
 #   発行：発行体 -> （申込なし）初期データ参照
 def test_applyForOffering_normal_2(web3, chain, users, coupon_exchange):
@@ -1312,6 +1411,7 @@ def test_applyForOffering_normal_2(web3, chain, users, coupon_exchange):
     chain.wait.for_receipt(txn_hash)
 
     assert coupon.call().applications(trader) == ''
+
 
 # エラー系1:
 #   発行：発行体 -> 投資家：募集申込（入力値の型誤り）
@@ -1332,7 +1432,8 @@ def test_applyForOffering_error_1(web3, chain, users, coupon_exchange):
     # 募集申込
     web3.eth.defaultAccount = trader
     with pytest.raises(TypeError):
-        txn_hash = coupon.transact().applyForOffering(1234)
+        coupon.transact().applyForOffering(1234)
+
 
 # エラー系2:
 #   発行：発行体 -> 投資家：募集申込（申込ステータスが停止中）
@@ -1352,9 +1453,12 @@ def test_applyForOffering_error_2(web3, chain, users, coupon_exchange):
 
     assert coupon.call().applications(trader) == ''
 
+
 '''
 TEST17_リターン詳細更新（setReturnDetails）
 '''
+
+
 # 正常系1: 発行 -> 詳細更新
 def test_setReturnDetails_normal_1(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -1373,6 +1477,7 @@ def test_setReturnDetails_normal_1(web3, chain, users, coupon_exchange):
     return_details = coupon.call().returnDetails()
     assert after_return_details == return_details
 
+
 # エラー系1: 入力値の型誤り
 def test_setReturnDetails_error_1(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -1387,6 +1492,7 @@ def test_setReturnDetails_error_1(web3, chain, users, coupon_exchange):
     with pytest.raises(TypeError):
         coupon.transact().setReturnDetails(1234)
 
+
 # エラー系2: 権限エラー
 def test_setReturnDetails_error_2(web3, chain, users, coupon_exchange):
     issuer = users['issuer']
@@ -1400,7 +1506,7 @@ def test_setReturnDetails_error_2(web3, chain, users, coupon_exchange):
 
     # リターン詳細更新：権限エラー
     web3.eth.defaultAccount = attacker
-    txn_hash = coupon.transact().setReturnDetails(after_return_details) # エラーになる
+    txn_hash = coupon.transact().setReturnDetails(after_return_details)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     return_details = coupon.call().returnDetails()

--- a/tests/test_ibetmembership.py
+++ b/tests/test_ibetmembership.py
@@ -1,11 +1,12 @@
 import pytest
 from eth_utils import to_checksum_address
 
+
 def init_args(exchange_address):
     name = 'test_membership'
     symbol = 'MEM'
     initial_supply = 10000
-    tradableExchange = exchange_address
+    tradable_exchange = exchange_address
     details = 'some_details'
     return_details = 'some_return'
     expiration_date = '20191231'
@@ -13,22 +14,26 @@ def init_args(exchange_address):
     transferable = True
 
     deploy_args = [
-        name, symbol, initial_supply, tradableExchange,
+        name, symbol, initial_supply, tradable_exchange,
         details, return_details,
         expiration_date, memo, transferable
     ]
     return deploy_args
 
+
 def deploy(chain, deploy_args):
     membership_contract, _ = chain.provider.get_or_deploy_contract(
         'IbetMembership',
-        deploy_args = deploy_args
+        deploy_args=deploy_args
     )
     return membership_contract
+
 
 '''
 TEST1_デプロイ
 '''
+
+
 # 正常系1: deploy
 def test_deploy_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -61,8 +66,9 @@ def test_deploy_normal_1(web3, chain, users, membership_exchange):
     assert expiration_date == deploy_args[6]
     assert memo == deploy_args[7]
     assert transferable == deploy_args[8]
-    assert status == True
+    assert status is True
     assert balance == deploy_args[2]
+
 
 # エラー系1: 入力値の型誤り（name）
 def test_deploy_error_1(chain, membership_exchange):
@@ -72,8 +78,9 @@ def test_deploy_error_1(chain, membership_exchange):
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
             'IbetMembership',
-            deploy_args = deploy_args
+            deploy_args=deploy_args
         )
+
 
 # エラー系2: 入力値の型誤り（symbol）
 def test_deploy_error_2(chain, membership_exchange):
@@ -83,8 +90,9 @@ def test_deploy_error_2(chain, membership_exchange):
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
             'IbetMembership',
-            deploy_args = deploy_args
+            deploy_args=deploy_args
         )
+
 
 # エラー系3: 入力値の型誤り（initialSupply）
 def test_deploy_error_3(chain, membership_exchange):
@@ -94,8 +102,9 @@ def test_deploy_error_3(chain, membership_exchange):
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
             'IbetMembership',
-            deploy_args = deploy_args
+            deploy_args=deploy_args
         )
+
 
 # エラー系4: 入力値の型誤り（details）
 def test_deploy_error_4(chain, membership_exchange):
@@ -105,8 +114,9 @@ def test_deploy_error_4(chain, membership_exchange):
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
             'IbetMembership',
-            deploy_args = deploy_args
+            deploy_args=deploy_args
         )
+
 
 # エラー系5: 入力値の型誤り（returnDetails）
 def test_deploy_error_5(chain, membership_exchange):
@@ -116,8 +126,9 @@ def test_deploy_error_5(chain, membership_exchange):
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
             'IbetMembership',
-            deploy_args = deploy_args
+            deploy_args=deploy_args
         )
+
 
 # エラー系6: 入力値の型誤り（expirationDate）
 def test_deploy_error_6(chain, membership_exchange):
@@ -127,8 +138,9 @@ def test_deploy_error_6(chain, membership_exchange):
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
             'IbetMembership',
-            deploy_args = deploy_args
+            deploy_args=deploy_args
         )
+
 
 # エラー系7: 入力値の型誤り（memo）
 def test_deploy_error_7(chain, membership_exchange):
@@ -138,8 +150,9 @@ def test_deploy_error_7(chain, membership_exchange):
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
             'IbetMembership',
-            deploy_args = deploy_args
+            deploy_args=deploy_args
         )
+
 
 # エラー系8: 入力値の型誤り（transferable）
 def test_deploy_error_8(chain, membership_exchange):
@@ -149,8 +162,9 @@ def test_deploy_error_8(chain, membership_exchange):
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
             'IbetMembership',
-            deploy_args = deploy_args
+            deploy_args=deploy_args
         )
+
 
 # エラー系8: 入力値の型誤り（tradableExchange）
 def test_deploy_error_9(chain, membership_exchange):
@@ -160,12 +174,15 @@ def test_deploy_error_9(chain, membership_exchange):
     with pytest.raises(TypeError):
         chain.provider.get_or_deploy_contract(
             'IbetMembership',
-            deploy_args = deploy_args
+            deploy_args=deploy_args
         )
+
 
 '''
 TEST2_トークンの振替（transfer）
 '''
+
+
 # 正常系1: アカウントアドレスへの振替
 def test_transfer_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -188,8 +205,9 @@ def test_transfer_normal_1(web3, chain, users, membership_exchange):
     assert issuer_balance == deploy_args[2] - transfer_amount
     assert trader_balance == transfer_amount
 
+
 # 正常系2: 会員権取引コントラクトへの振替
-def test_transfer_normal_2(web3,chain, users, membership_exchange):
+def test_transfer_normal_2(web3, chain, users, membership_exchange):
     issuer = users['issuer']
     transfer_amount = 100
 
@@ -208,6 +226,7 @@ def test_transfer_normal_2(web3,chain, users, membership_exchange):
     assert issuer_balance == deploy_args[2] - transfer_amount
     assert exchange_balance == transfer_amount
 
+
 # 正常系3-1: 限界値：上限値
 # アカウントアドレスへの振替
 def test_transfer_normal_3_1(web3, chain, users, membership_exchange):
@@ -217,17 +236,18 @@ def test_transfer_normal_3_1(web3, chain, users, membership_exchange):
     # 発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256-1 # 上限まで発行する
+    deploy_args[2] = 2 ** 256 - 1  # 上限まで発行する
     membership_contract = deploy(chain, deploy_args)
 
     # 振替
     web3.eth.defaultAccount = issuer
-    transfer_amount = 2**256-1
+    transfer_amount = 2 ** 256 - 1
     txn_hash = membership_contract.transact().transfer(trader, transfer_amount)
     chain.wait.for_receipt(txn_hash)
 
     assert membership_contract.call().balanceOf(issuer) == 0
-    assert membership_contract.call().balanceOf(trader) == 2**256-1
+    assert membership_contract.call().balanceOf(trader) == 2 ** 256 - 1
+
 
 # 正常系3-2: 限界値：下限値
 # アカウントアドレスへの振替
@@ -250,6 +270,7 @@ def test_transfer_normal_3_2(web3, chain, users, membership_exchange):
     assert membership_contract.call().balanceOf(issuer) == 0
     assert membership_contract.call().balanceOf(trader) == 0
 
+
 # 正常系3-3: 限界値：上限値
 # コントラクトアドレスへの振替
 def test_transfer_normal_3_3(web3, chain, users, membership_exchange):
@@ -258,19 +279,20 @@ def test_transfer_normal_3_3(web3, chain, users, membership_exchange):
     # 発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256-1 # 上限まで発行する
+    deploy_args[2] = 2 ** 256 - 1  # 上限まで発行する
     membership_contract = deploy(chain, deploy_args)
 
     # 振替
     web3.eth.defaultAccount = issuer
     exchange_address = membership_exchange.address
-    transfer_amount = 2**256-1
-    txn_hash = membership_contract.transact().\
+    transfer_amount = 2 ** 256 - 1
+    txn_hash = membership_contract.transact(). \
         transfer(exchange_address, transfer_amount)
     chain.wait.for_receipt(txn_hash)
 
     assert membership_contract.call().balanceOf(issuer) == 0
-    assert membership_contract.call().balanceOf(exchange_address) == 2**256-1
+    assert membership_contract.call().balanceOf(exchange_address) == 2 ** 256 - 1
+
 
 # 正常系3-4: 限界値：下限値
 # コントラクトアドレスへの振替
@@ -287,12 +309,13 @@ def test_transfer_normal_3_4(web3, chain, users, membership_exchange):
     web3.eth.defaultAccount = issuer
     exchange_address = membership_exchange.address
     transfer_amount = 0
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transfer(exchange_address, transfer_amount)
     chain.wait.for_receipt(txn_hash)
 
     assert membership_contract.call().balanceOf(issuer) == 0
     assert membership_contract.call().balanceOf(exchange_address) == 0
+
 
 # エラー系1-1: 入力値の型誤り（to）
 def test_transfer_error_1_1(web3, chain, users, membership_exchange):
@@ -308,6 +331,7 @@ def test_transfer_error_1_1(web3, chain, users, membership_exchange):
     # 振替
     with pytest.raises(TypeError):
         membership_contract.transact().transfer(to, transfer_amount)
+
 
 # エラー系1-2: 入力値の型誤り（value）
 def test_transfer_error_1_2(web3, chain, users, membership_exchange):
@@ -331,6 +355,7 @@ def test_transfer_error_1_2(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_contract.transact().transfer(to, -1)
 
+
 # エラー系2: 限界値超
 def test_transfer_error_2(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -343,11 +368,12 @@ def test_transfer_error_2(web3, chain, users, membership_exchange):
 
     # 振替（上限値超え）
     with pytest.raises(TypeError):
-        membership_contract.transact().transfer(to, 2**256)
+        membership_contract.transact().transfer(to, 2 ** 256)
 
     # 振替（下限値超え）
     with pytest.raises(TypeError):
         membership_contract.transact().transfer(to, -1)
+
 
 # エラー系3: 残高不足
 def test_transfer_error_3(web3, chain, users, membership_exchange):
@@ -367,6 +393,7 @@ def test_transfer_error_3(web3, chain, users, membership_exchange):
 
     assert membership_contract.call().balanceOf(issuer) == deploy_args[2]
     assert membership_contract.call().balanceOf(trader) == 0
+
 
 # エラー系4: private functionにアクセスできない
 def test_transfer_error_4(web3, chain, users, membership_exchange):
@@ -390,6 +417,7 @@ def test_transfer_error_4(web3, chain, users, membership_exchange):
     with pytest.raises(ValueError):
         membership_contract.transact().transferToContract(trader, transfer_amount, data)
 
+
 # エラー系5: 譲渡不可
 def test_transfer_error_5(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -404,15 +432,17 @@ def test_transfer_error_5(web3, chain, users, membership_exchange):
     # 振替：譲渡不可
     web3.eth.defaultAccount = issuer
     transfer_amount = 10
-    txn_hash = membership_contract.transact().\
-        transfer(trader, transfer_amount) # エラーになる
+    txn_hash = membership_contract.transact(). \
+        transfer(trader, transfer_amount)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     assert membership_contract.call().balanceOf(issuer) == deploy_args[2]
     assert membership_contract.call().balanceOf(trader) == 0
 
+
 # エラー系6: 取引不可Exchangeへの振替
-def test_transfer_error_6(web3, chain, users, membership_exchange, payment_gateway):
+def test_transfer_error_6(web3, chain, users, membership_exchange,
+                          membership_exchange_storage, payment_gateway):
     issuer = users['issuer']
 
     # 新規発行
@@ -423,23 +453,26 @@ def test_transfer_error_6(web3, chain, users, membership_exchange, payment_gatew
     # 取引不可Exchange
     web3.eth.defaultAccount = users['admin']
     dummy_exchange, _ = chain.provider.get_or_deploy_contract(
-        'IbetCouponExchange', # IbetMembershipExchange以外を読み込む必要がある
-        deploy_args = [payment_gateway.address]
+        'IbetCouponExchange',  # IbetMembershipExchange以外を読み込む必要がある
+        deploy_args=[payment_gateway.address, membership_exchange_storage.address]
     )
 
     # 振替
     web3.eth.defaultAccount = issuer
     transfer_amount = 10
-    txn_hash = membership_contract.transact().\
-        transfer(dummy_exchange.address, transfer_amount) # エラーになる
+    txn_hash = membership_contract.transact(). \
+        transfer(dummy_exchange.address, transfer_amount)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     assert membership_contract.call().balanceOf(issuer) == deploy_args[2]
     assert membership_contract.call().balanceOf(dummy_exchange.address) == 0
 
+
 '''
 TEST3_トークンの移転（transferFrom）
 '''
+
+
 # 正常系1: アカウントアドレスへの移転
 def test_transferFrom_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -454,13 +487,13 @@ def test_transferFrom_normal_1(web3, chain, users, membership_exchange):
 
     # 譲渡（issuer -> from_address）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transfer(from_address, value)
     chain.wait.for_receipt(txn_hash)
 
     # 移転（_from -> _to）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transferFrom(from_address, to_address, value)
     chain.wait.for_receipt(txn_hash)
 
@@ -471,6 +504,7 @@ def test_transferFrom_normal_1(web3, chain, users, membership_exchange):
     assert issuer_balance == deploy_args[2] - value
     assert from_balance == 0
     assert to_balance == value
+
 
 # 正常系2: コントラクトアドレスへの移転
 def test_transferFrom_normal_2(web3, chain, users, membership_exchange):
@@ -486,13 +520,13 @@ def test_transferFrom_normal_2(web3, chain, users, membership_exchange):
 
     # 譲渡（issuer -> from_address）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transfer(from_address, value)
     chain.wait.for_receipt(txn_hash)
 
     # 移転（_from -> _to）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transferFrom(from_address, to_address, value)
     chain.wait.for_receipt(txn_hash)
 
@@ -504,13 +538,14 @@ def test_transferFrom_normal_2(web3, chain, users, membership_exchange):
     assert from_balance == 0
     assert to_balance == value
 
+
 # 正常系3-1: 限界値：上限値
 #  アカウントアドレスへの移転
 def test_transferFrom_normal_3_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
     from_address = users['admin']
     to_address = users['trader']
-    max_value = 2**256 - 1
+    max_value = 2 ** 256 - 1
 
     # 発行
     web3.eth.defaultAccount = issuer
@@ -520,13 +555,13 @@ def test_transferFrom_normal_3_1(web3, chain, users, membership_exchange):
 
     # 譲渡（issuer -> from_address）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transfer(from_address, max_value)
     chain.wait.for_receipt(txn_hash)
 
     # 移転（from -> to）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transferFrom(from_address, to_address, max_value)
     chain.wait.for_receipt(txn_hash)
 
@@ -537,6 +572,7 @@ def test_transferFrom_normal_3_1(web3, chain, users, membership_exchange):
     assert issuer_balance == 0
     assert from_balance == 0
     assert to_balance == max_value
+
 
 # 正常系3-2: 限界値：下限値
 #  アカウントアドレスへの移転
@@ -554,13 +590,13 @@ def test_transferFrom_normal_3_2(web3, chain, users, membership_exchange):
 
     # 譲渡（issuer -> from_address）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transfer(from_address, min_value)
     chain.wait.for_receipt(txn_hash)
 
     # 移転（from -> to）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transferFrom(from_address, to_address, min_value)
     chain.wait.for_receipt(txn_hash)
 
@@ -572,12 +608,13 @@ def test_transferFrom_normal_3_2(web3, chain, users, membership_exchange):
     assert from_balance == 0
     assert to_balance == 0
 
+
 # 正常系3-3: 限界値：上限値
 #  コントラクトアドレスへの移転
 def test_transferFrom_normal_3_3(web3, chain, users, membership_exchange):
     issuer = users['issuer']
     from_address = users['admin']
-    max_value = 2**256 - 1
+    max_value = 2 ** 256 - 1
 
     # 発行
     web3.eth.defaultAccount = issuer
@@ -588,20 +625,20 @@ def test_transferFrom_normal_3_3(web3, chain, users, membership_exchange):
     # Exchangeコントラクトのデプロイ
     exchange_contract, _ = chain.provider.get_or_deploy_contract(
         'IbetMembershipExchange',
-        deploy_transaction = {'gas':6000000},
-        deploy_args = []
+        deploy_transaction={'gas': 6000000},
+        deploy_args=[]
     )
     to_address = exchange_contract.address
 
     # 譲渡（issuer -> from_address）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transfer(from_address, max_value)
     chain.wait.for_receipt(txn_hash)
 
     # 移転（from -> to）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transferFrom(from_address, to_address, max_value)
     chain.wait.for_receipt(txn_hash)
 
@@ -612,6 +649,7 @@ def test_transferFrom_normal_3_3(web3, chain, users, membership_exchange):
     assert issuer_balance == 0
     assert from_balance == 0
     assert to_balance == max_value
+
 
 # 正常系3-4: 限界値：下限値
 #  コントラクトアドレスへの移転
@@ -629,20 +667,20 @@ def test_transferFrom_normal_3_4(web3, chain, users, membership_exchange):
     # Exchangeコントラクトのデプロイ
     exchange_contract, _ = chain.provider.get_or_deploy_contract(
         'IbetMembershipExchange',
-        deploy_transaction = {'gas':6000000},
-        deploy_args = []
+        deploy_transaction={'gas': 6000000},
+        deploy_args=[]
     )
     to_address = exchange_contract.address
 
     # 譲渡（issuer -> from_address）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transfer(from_address, min_value)
     chain.wait.for_receipt(txn_hash)
 
     # 移転（from -> to）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         transferFrom(from_address, to_address, min_value)
     chain.wait.for_receipt(txn_hash)
 
@@ -653,6 +691,7 @@ def test_transferFrom_normal_3_4(web3, chain, users, membership_exchange):
     assert issuer_balance == 0
     assert from_balance == 0
     assert to_balance == 0
+
 
 # エラー系1-1: 入力値の型誤り（from_address）
 def test_transferFrom_error_1_1(web3, chain, users, membership_exchange):
@@ -668,14 +707,15 @@ def test_transferFrom_error_1_1(web3, chain, users, membership_exchange):
     # String
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
-        membership_contract.transact().\
+        membership_contract.transact(). \
             transferFrom('1234', to_address, value)
 
     # Int
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
-        membership_contract.transact().\
+        membership_contract.transact(). \
             transferFrom(1234, to_address, value)
+
 
 # エラー系1-2: 入力値の型誤り（to_address）
 def test_transferFrom_error_1_2(web3, chain, users, membership_exchange):
@@ -690,14 +730,15 @@ def test_transferFrom_error_1_2(web3, chain, users, membership_exchange):
     # String
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
-        membership_contract.transact().\
+        membership_contract.transact(). \
             transferFrom(issuer, '1234', value)
 
     # Int
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
-        membership_contract.transact().\
+        membership_contract.transact(). \
             transferFrom(issuer, 1234, value)
+
 
 # エラー系1-3: 入力値の型誤り（value）
 def test_transferFrom_error_1_3(web3, chain, users, membership_exchange):
@@ -712,20 +753,21 @@ def test_transferFrom_error_1_3(web3, chain, users, membership_exchange):
     # String
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
-        membership_contract.transact().\
+        membership_contract.transact(). \
             transferFrom(issuer, to_address, '100')
 
     # 小数
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
-        membership_contract.transact().\
+        membership_contract.transact(). \
             transferFrom(issuer, to_address, 100.0)
 
     # 負の値
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
-        membership_contract.transact().\
+        membership_contract.transact(). \
             transferFrom(issuer, to_address, -1)
+
 
 # エラー系2: 限界値超
 def test_transferFrom_error_2(web3, chain, users, membership_exchange):
@@ -740,14 +782,15 @@ def test_transferFrom_error_2(web3, chain, users, membership_exchange):
     # 上限値超
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
-        membership_contract.transact().\
-            transferFrom(issuer, to_address, 2**256)
+        membership_contract.transact(). \
+            transferFrom(issuer, to_address, 2 ** 256)
 
     # 下限値超
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
-        membership_contract.transact().\
+        membership_contract.transact(). \
             transferFrom(issuer, to_address, -1)
+
 
 # エラー系3: 残高不足
 def test_transferFrom_error_3(web3, chain, users, membership_exchange):
@@ -762,12 +805,13 @@ def test_transferFrom_error_3(web3, chain, users, membership_exchange):
     # 残高超
     web3.eth.defaultAccount = issuer
     transfer_amount = 10000000000
-    txn_hash = membership_contract.transact().\
-            transferFrom(issuer, to_address, transfer_amount)
+    txn_hash = membership_contract.transact(). \
+        transferFrom(issuer, to_address, transfer_amount)
     chain.wait.for_receipt(txn_hash)
 
     assert membership_contract.call().balanceOf(issuer) == deploy_args[2]
     assert membership_contract.call().balanceOf(to_address) == 0
+
 
 # エラー系4: 権限エラー（発行者以外が実行）
 def test_transferFrom_error_4(web3, chain, users, membership_exchange):
@@ -783,16 +827,19 @@ def test_transferFrom_error_4(web3, chain, users, membership_exchange):
 
     # 残高超
     web3.eth.defaultAccount = admin
-    txn_hash = membership_contract.transact().\
-        transferFrom(issuer, to_address, transfer_amount) # エラーになる
+    txn_hash = membership_contract.transact(). \
+        transferFrom(issuer, to_address, transfer_amount)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     assert membership_contract.call().balanceOf(issuer) == deploy_args[2]
     assert membership_contract.call().balanceOf(to_address) == 0
 
+
 '''
 TEST4_残高確認（balanceOf）
 '''
+
+
 # 正常系1: 発行 -> 残高確認
 def test_balanceOf_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -804,6 +851,7 @@ def test_balanceOf_normal_1(web3, chain, users, membership_exchange):
 
     balance = membership_contract.call().balanceOf(issuer)
     assert balance == deploy_args[2]
+
 
 # 正常系2: データなし -> 残高ゼロ
 def test_balanceOf_normal_2(web3, chain, users, membership_exchange):
@@ -817,6 +865,7 @@ def test_balanceOf_normal_2(web3, chain, users, membership_exchange):
 
     balance = membership_contract.call().balanceOf(trader)
     assert balance == 0
+
 
 # エラー系1: 入力値の型誤り
 def test_balanceOf_error_1(web3, chain, users, membership_exchange):
@@ -835,9 +884,12 @@ def test_balanceOf_error_1(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_contract.call().balanceOf(1234)
 
+
 '''
 TEST5_会員権詳細更新（setDetails）
 '''
+
+
 # 正常系1: 発行 -> 詳細更新
 def test_setDetails_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -850,12 +902,13 @@ def test_setDetails_normal_1(web3, chain, users, membership_exchange):
 
     # 会員権詳細更新
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         setDetails(after_details)
     chain.wait.for_receipt(txn_hash)
 
     details = membership_contract.call().details()
     assert after_details == details
+
 
 # エラー系1: 入力値の型誤り
 def test_setDetails_error_1(web3, chain, users, membership_exchange):
@@ -871,6 +924,7 @@ def test_setDetails_error_1(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_contract.transact().setDetails(1234)
 
+
 # エラー系2: 権限エラー
 def test_setDetails_error_2(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -884,16 +938,19 @@ def test_setDetails_error_2(web3, chain, users, membership_exchange):
 
     # 会員権詳細更新
     web3.eth.defaultAccount = attacker
-    txn_hash = membership_contract.transact().\
-        setDetails(after_details) # エラーになる
+    txn_hash = membership_contract.transact(). \
+        setDetails(after_details)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     details = membership_contract.call().details()
     assert details == deploy_args[4]
 
+
 '''
 TEST6_リターン詳細更新（setReturnDetails）
 '''
+
+
 # 正常系1: 発行 -> 詳細更新
 def test_setReturnDetails_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -906,12 +963,13 @@ def test_setReturnDetails_normal_1(web3, chain, users, membership_exchange):
 
     # リターン詳細更新
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         setReturnDetails(after_return_details)
     chain.wait.for_receipt(txn_hash)
 
     return_details = membership_contract.call().returnDetails()
     assert after_return_details == return_details
+
 
 # エラー系1: 入力値の型誤り
 def test_setReturnDetails_error_1(web3, chain, users, membership_exchange):
@@ -927,6 +985,7 @@ def test_setReturnDetails_error_1(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_contract.transact().setReturnDetails(1234)
 
+
 # エラー系2: 権限エラー
 def test_setReturnDetails_error_2(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -940,16 +999,19 @@ def test_setReturnDetails_error_2(web3, chain, users, membership_exchange):
 
     # リターン詳細更新：権限エラー
     web3.eth.defaultAccount = attacker
-    txn_hash = membership_contract.transact().\
-        setReturnDetails(after_return_details) # エラーになる
+    txn_hash = membership_contract.transact(). \
+        setReturnDetails(after_return_details)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     return_details = membership_contract.call().returnDetails()
     assert return_details == deploy_args[5]
 
+
 '''
 TEST7_有効期限更新（setExpirationDate）
 '''
+
+
 # 正常系1: 発行 -> 有効期限更新
 def test_setExpirationDate_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -962,12 +1024,13 @@ def test_setExpirationDate_normal_1(web3, chain, users, membership_exchange):
 
     # 有効期限更新
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         setExpirationDate(after_expiration_date)
     chain.wait.for_receipt(txn_hash)
 
     expiration_date = membership_contract.call().expirationDate()
     assert after_expiration_date == expiration_date
+
 
 # エラー系1: 入力値の型誤り
 def test_setExpirationDate_errors_1(web3, chain, users, membership_exchange):
@@ -983,6 +1046,7 @@ def test_setExpirationDate_errors_1(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_contract.transact().setExpirationDate(1234)
 
+
 # エラー系2: 権限エラー
 def test_setExpirationDate_error_2(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -996,16 +1060,19 @@ def test_setExpirationDate_error_2(web3, chain, users, membership_exchange):
 
     # 有効期限更新：権限エラー
     web3.eth.defaultAccount = attacker
-    txn_hash = membership_contract.transact().\
-        setExpirationDate(after_expiration_date) # エラーになる
+    txn_hash = membership_contract.transact(). \
+        setExpirationDate(after_expiration_date)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     expiration_date = membership_contract.call().expirationDate()
     assert expiration_date == deploy_args[6]
 
+
 '''
 TEST8_メモ欄更新（setMemo）
 '''
+
+
 # 正常系1: 発行 -> メモ欄更新
 def test_setMemo_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1024,6 +1091,7 @@ def test_setMemo_normal_1(web3, chain, users, membership_exchange):
     memo = membership_contract.call().memo()
     assert after_memo == memo
 
+
 # エラー系1: 入力値の型誤り
 def test_setMemo_error_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1038,6 +1106,7 @@ def test_setMemo_error_1(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_contract.transact().setMemo(1234)
 
+
 # エラー系1: 権限エラー
 def test_setMemo_error_2(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1051,15 +1120,18 @@ def test_setMemo_error_2(web3, chain, users, membership_exchange):
 
     # メモ欄更新：権限エラー
     web3.eth.defaultAccount = attacker
-    txn_hash = membership_contract.transact().setMemo(after_memo) # エラーになる
+    txn_hash = membership_contract.transact().setMemo(after_memo)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     memo = membership_contract.call().memo()
     assert memo == deploy_args[7]
 
+
 '''
 TEST9_譲渡可能更新（setTransferable）
 '''
+
+
 # 正常系1: 発行 -> 譲渡可能更新
 def test_setTransferable_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1078,6 +1150,7 @@ def test_setTransferable_normal_1(web3, chain, users, membership_exchange):
     transferable = membership_contract.call().transferable()
     assert after_transferable == transferable
 
+
 # エラー系1: 入力値の型誤り
 def test_setTransferable_error_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1092,6 +1165,7 @@ def test_setTransferable_error_1(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_contract.transact().setTransferable('True')
 
+
 # エラー系2: 権限エラー
 def test_setTransferable_error_2(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1105,16 +1179,19 @@ def test_setTransferable_error_2(web3, chain, users, membership_exchange):
 
     # 譲渡可能更新
     web3.eth.defaultAccount = attacker
-    txn_hash = membership_contract.transact().\
-        setTransferable(after_transferable) # エラーになる
+    txn_hash = membership_contract.transact(). \
+        setTransferable(after_transferable)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     transferable = membership_contract.call().transferable()
     assert transferable == deploy_args[8]
 
+
 '''
 TEST10_取扱ステータス更新（setStatus）
 '''
+
+
 # 正常系1: 発行 -> 取扱ステータス更新
 def test_setStatus_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1133,6 +1210,7 @@ def test_setStatus_normal_1(web3, chain, users, membership_exchange):
     status = membership_contract.call().status()
     assert after_status == status
 
+
 # エラー系1: 入力値の型誤り
 def test_setStatus_error_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1147,6 +1225,7 @@ def test_setStatus_error_1(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_contract.transact().setStatus('True')
 
+
 # エラー系2: 権限エラー
 def test_setStatus_error_2(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1160,16 +1239,19 @@ def test_setStatus_error_2(web3, chain, users, membership_exchange):
 
     # 取扱ステータス更新
     web3.eth.defaultAccount = attacker
-    txn_hash = membership_contract.transact().\
-        setStatus(after_status) # エラーになる
+    txn_hash = membership_contract.transact(). \
+        setStatus(after_status)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     status = membership_contract.call().status()
-    assert status == True
+    assert status is True
+
 
 '''
 TEST11_商品画像更新（setImageURL, getImageURL）
 '''
+
+
 # 正常系1: 発行 -> 商品画像更新
 def test_setImageURL_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1188,6 +1270,7 @@ def test_setImageURL_normal_1(web3, chain, users, membership_exchange):
     url = membership_contract.call().getImageURL(0)
     assert after_url == url
 
+
 # エラー系1-1: 入力値の型誤り：Class
 def test_setImageURL_error_1_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1201,6 +1284,7 @@ def test_setImageURL_error_1_1(web3, chain, users, membership_exchange):
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
         membership_contract.transact().setImageURL('0', 'after_url')
+
 
 # エラー系1-2: 入力値の型誤り：ImageURL
 def test_setImageURL_error_1_2(web3, chain, users, membership_exchange):
@@ -1216,6 +1300,7 @@ def test_setImageURL_error_1_2(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_contract.transact().setImageURL(0, 1234)
 
+
 # エラー系2: 権限エラー
 def test_setImageURL_error_2(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1229,16 +1314,19 @@ def test_setImageURL_error_2(web3, chain, users, membership_exchange):
 
     # 商品画像更新
     web3.eth.defaultAccount = attacker
-    txn_hash = membership_contract.transact().\
-        setImageURL(0, after_url) # エラーになる
+    txn_hash = membership_contract.transact(). \
+        setImageURL(0, after_url)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     url = membership_contract.call().getImageURL(0)
     assert url == ''
 
+
 '''
 TEST12_追加発行（issue）
 '''
+
+
 # 正常系1: 発行 -> 追加発行
 def test_issue_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1260,6 +1348,7 @@ def test_issue_normal_1(web3, chain, users, membership_exchange):
     assert total_supply == deploy_args[2] + value
     assert balance == deploy_args[2] + value
 
+
 # 正常系2: 限界値
 def test_issue_normal_2(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1267,7 +1356,7 @@ def test_issue_normal_2(web3, chain, users, membership_exchange):
     # 発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 2
+    deploy_args[2] = 2 ** 256 - 2
     membership_contract = deploy(chain, deploy_args)
 
     # 追加発行（限界値）
@@ -1278,8 +1367,9 @@ def test_issue_normal_2(web3, chain, users, membership_exchange):
     total_supply = membership_contract.call().totalSupply()
     balance = membership_contract.call().balanceOf(issuer)
 
-    assert total_supply == 2**256 - 1
-    assert balance == 2**256 - 1
+    assert total_supply == 2 ** 256 - 1
+    assert balance == 2 ** 256 - 1
+
 
 # エラー系1: 入力値の型誤り
 def test_issue_error_1(web3, chain, users, membership_exchange):
@@ -1298,6 +1388,7 @@ def test_issue_error_1(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_contract.transact().issue(1.0)
 
+
 # エラー系2: 限界値超
 def test_issue_error_2(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1309,11 +1400,12 @@ def test_issue_error_2(web3, chain, users, membership_exchange):
 
     # 上限値超
     with pytest.raises(TypeError):
-        membership_contract.transact().issue(2**256)
+        membership_contract.transact().issue(2 ** 256)
 
     # 下限値超
     with pytest.raises(TypeError):
         membership_contract.transact().issue(-1)
+
 
 # エラー系3: 発行→追加発行→上限界値超
 def test_issue_error_3(web3, chain, users, membership_exchange):
@@ -1322,12 +1414,12 @@ def test_issue_error_3(web3, chain, users, membership_exchange):
     # 発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1 # 限界値
+    deploy_args[2] = 2 ** 256 - 1  # 限界値
     membership_contract = deploy(chain, deploy_args)
 
     # 追加発行（限界値超）
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().issue(1) # エラーになる
+    txn_hash = membership_contract.transact().issue(1)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     total_supply = membership_contract.call().totalSupply()
@@ -1335,6 +1427,7 @@ def test_issue_error_3(web3, chain, users, membership_exchange):
 
     assert total_supply == deploy_args[2]
     assert balance == deploy_args[2]
+
 
 # エラー系4: 権限エラー
 def test_issue_error_4(web3, chain, users, membership_exchange):
@@ -1348,7 +1441,7 @@ def test_issue_error_4(web3, chain, users, membership_exchange):
 
     # 追加発行：権限エラー
     web3.eth.defaultAccount = attacker
-    txn_hash = membership_contract.transact().issue(1) # エラーになる
+    txn_hash = membership_contract.transact().issue(1)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     total_supply = membership_contract.call().totalSupply()
@@ -1357,11 +1450,15 @@ def test_issue_error_4(web3, chain, users, membership_exchange):
     assert total_supply == deploy_args[2]
     assert balance == deploy_args[2]
 
+
 '''
 TEST13_取引可能Exchangeの更新（setTradableExchange）
 '''
+
+
 # 正常系1: 発行 -> Exchangeの更新
-def test_setTradableExchange_normal_1(web3, chain, users, membership_exchange, payment_gateway):
+def test_setTradableExchange_normal_1(web3, chain, users, membership_exchange,
+                                      membership_exchange_storage, payment_gateway):
     issuer = users['issuer']
 
     # トークン新規発行
@@ -1372,18 +1469,18 @@ def test_setTradableExchange_normal_1(web3, chain, users, membership_exchange, p
     # その他Exchange
     web3.eth.defaultAccount = users['admin']
     other_exchange, _ = chain.provider.get_or_deploy_contract(
-        'IbetCouponExchange', # IbetMembershipExchange以外を読み込む必要がある
-        deploy_args = [payment_gateway.address]
+        'IbetCouponExchange',  # IbetMembershipExchange以外を読み込む必要がある
+        deploy_args=[payment_gateway.address, membership_exchange_storage.address]
     )
 
     # Exchangeの更新
     web3.eth.defaultAccount = issuer
-    txn_hash = membership_contract.transact().\
+    txn_hash = membership_contract.transact(). \
         setTradableExchange(other_exchange.address)
     chain.wait.for_receipt(txn_hash)
 
-    assert membership_contract.call().tradableExchange() == \
-        to_checksum_address(other_exchange.address)
+    assert membership_contract.call().tradableExchange() == to_checksum_address(other_exchange.address)
+
 
 # エラー系1: 発行 -> Exchangeの更新（入力値の型誤り）
 def test_setTradableExchange_error_1(web3, chain, users, membership_exchange):
@@ -1399,8 +1496,10 @@ def test_setTradableExchange_error_1(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_contract.transact().setTradableExchange('0xaaaa')
 
+
 # エラー系2: 発行 -> Exchangeの更新（権限エラー）
-def test_setTradableExchange_error_2(web3, chain, users, membership_exchange, payment_gateway):
+def test_setTradableExchange_error_2(web3, chain, users, membership_exchange,
+                                     membership_exchange_storage, payment_gateway):
     issuer = users['issuer']
     trader = users['trader']
 
@@ -1412,22 +1511,24 @@ def test_setTradableExchange_error_2(web3, chain, users, membership_exchange, pa
     # その他Exchange
     web3.eth.defaultAccount = users['admin']
     other_exchange, _ = chain.provider.get_or_deploy_contract(
-        'IbetCouponExchange', # IbetMembershipExchange以外を読み込む必要がある
-        deploy_args = [payment_gateway.address]
+        'IbetCouponExchange',  # IbetMembershipExchange以外を読み込む必要がある
+        deploy_args=[payment_gateway.address, membership_exchange_storage.address]
     )
 
     # Exchangeの更新
     web3.eth.defaultAccount = trader
-    txn_hash = membership_contract.transact().\
-        setTradableExchange(other_exchange.address) #エラーになる
+    txn_hash = membership_contract.transact(). \
+        setTradableExchange(other_exchange.address)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
-    assert membership_contract.call().tradableExchange() == \
-        to_checksum_address(membership_exchange.address)
+    assert membership_contract.call().tradableExchange() == to_checksum_address(membership_exchange.address)
+
 
 '''
 TEST14_新規募集ステータス更新（setInitialOfferingStatus）
 '''
+
+
 # 正常系1: 発行 -> 新規募集ステータス更新（False→True）
 def test_setInitialOfferingStatus_normal_1(web3, chain, users, membership_exchange):
     issuer = users['issuer']
@@ -1438,14 +1539,15 @@ def test_setInitialOfferingStatus_normal_1(web3, chain, users, membership_exchan
     membership_contract = deploy(chain, deploy_args)
 
     # 初期状態 == False
-    assert membership_contract.call().initialOfferingStatus() == False
+    assert membership_contract.call().initialOfferingStatus() is False
 
     # 新規募集ステータスの更新
     web3.eth.defaultAccount = issuer
     txn_hash = membership_contract.transact().setInitialOfferingStatus(True)
     chain.wait.for_receipt(txn_hash)
 
-    assert membership_contract.call().initialOfferingStatus() == True
+    assert membership_contract.call().initialOfferingStatus() is True
+
 
 # 正常系2:
 #   発行 -> 新規募集ステータス更新（False→True） -> 2回目更新（True→False）
@@ -1467,7 +1569,8 @@ def test_setInitialOfferingStatus_normal_2(web3, chain, users, membership_exchan
     txn_hash = membership_contract.transact().setInitialOfferingStatus(False)
     chain.wait.for_receipt(txn_hash)
 
-    assert membership_contract.call().initialOfferingStatus() == False
+    assert membership_contract.call().initialOfferingStatus() is False
+
 
 # エラー系1: 発行 -> 新規募集ステータス更新（入力値の型誤り）
 def test_setInitialOfferingStatus_error_1(web3, chain, users, membership_exchange):
@@ -1483,9 +1586,12 @@ def test_setInitialOfferingStatus_error_1(web3, chain, users, membership_exchang
     with pytest.raises(TypeError):
         membership_contract.transact().setInitialOfferingStatus('True')
 
+
 '''
 TEST15_募集申込（applyForOffering）
 '''
+
+
 # 正常系1
 #   発行：発行体 -> 投資家：募集申込
 def test_applyForOffering_normal_1(web3, chain, users, membership_exchange):
@@ -1509,6 +1615,7 @@ def test_applyForOffering_normal_1(web3, chain, users, membership_exchange):
 
     assert membership_contract.call().applications(trader) == 'abcdefgh'
 
+
 # 正常系2
 #   発行：発行体 -> （申込なし）初期データ参照
 def test_applyForOffering_normal_2(web3, chain, users, membership_exchange):
@@ -1526,6 +1633,7 @@ def test_applyForOffering_normal_2(web3, chain, users, membership_exchange):
     chain.wait.for_receipt(txn_hash)
 
     assert membership_contract.call().applications(trader) == ''
+
 
 # エラー系1:
 #   発行：発行体 -> 投資家：募集申込（入力値の型誤り）
@@ -1546,7 +1654,8 @@ def test_applyForOffering_error_1(web3, chain, users, membership_exchange):
     # 募集申込
     web3.eth.defaultAccount = trader
     with pytest.raises(TypeError):
-        txn_hash = membership_contract.transact().applyForOffering(1234)
+        membership_contract.transact().applyForOffering(1234)
+
 
 # エラー系2:
 #   発行：発行体 -> 投資家：募集申込（申込ステータスが停止中）

--- a/tests/test_ibetmembershipexchange.py
+++ b/tests/test_ibetmembershipexchange.py
@@ -4,6 +4,8 @@ from eth_utils import to_checksum_address
 '''
 共通処理
 '''
+
+
 def init_args(exchange_address):
     name = 'test_membership'
     symbol = 'MEM'
@@ -22,12 +24,14 @@ def init_args(exchange_address):
     ]
     return deploy_args
 
+
 def deploy(chain, deploy_args):
     membership_contract, _ = chain.provider.get_or_deploy_contract(
         'IbetMembership',
-        deploy_args = deploy_args
+        deploy_args=deploy_args
     )
     return membership_contract
+
 
 # deposit
 def deposit(web3, chain, token, exchange, account, amount):
@@ -35,52 +39,65 @@ def deposit(web3, chain, token, exchange, account, amount):
     txn_hash = token.transact().transfer(exchange.address, amount)
     chain.wait.for_receipt(txn_hash)
 
+
 # make order
 def make_order(web3, chain, token, exchange, account,
-    amount, price, isBuy, agent):
+               amount, price, isBuy, agent):
     web3.eth.defaultAccount = account
     txn_hash = exchange.transact().createOrder(
         token.address, amount, price, isBuy, agent)
     chain.wait.for_receipt(txn_hash)
 
+
 # take order
 def take_order(web3, chain, token, exchange, account,
-    order_id, amount, isBuy):
+               order_id, amount, isBuy):
     web3.eth.defaultAccount = account
     txn_hash = exchange.transact().executeOrder(
         order_id, amount, isBuy)
     chain.wait.for_receipt(txn_hash)
 
+
 # settlement
 def settlement(web3, chain, token, exchange, account,
-    order_id, agreement_id):
+               order_id, agreement_id):
     web3.eth.defaultAccount = account
     txn_hash = exchange.transact().confirmAgreement(
         order_id, agreement_id)
     chain.wait.for_receipt(txn_hash)
 
+
 # settlement_ng
 def settlement_ng(web3, chain, token, exchange, account,
-    order_id, agreement_id):
+                  order_id, agreement_id):
     web3.eth.defaultAccount = account
     txn_hash = exchange.transact().cancelAgreement(
         order_id, agreement_id)
     chain.wait.for_receipt(txn_hash)
 
+
 '''
 TEST1_デプロイ
 '''
+
+
 # 正常系1: Deploy　→　正常
-def test_deploy_normal_1(users, membership_exchange, payment_gateway):
+def test_deploy_normal_1(users, membership_exchange, membership_exchange_storage,
+                         payment_gateway):
     owner = membership_exchange.call().owner()
-    paymentGatewayAddress = membership_exchange.call().paymentGatewayAddress()
+    payment_gateway_address = membership_exchange.call().paymentGatewayAddress()
+    storage_address = membership_exchange.call().storageAddress()
 
     assert owner == users['admin']
-    assert paymentGatewayAddress == to_checksum_address(payment_gateway.address)
+    assert payment_gateway_address == to_checksum_address(payment_gateway.address)
+    assert storage_address == to_checksum_address(membership_exchange_storage.address)
+
 
 '''
 TEST2_Make注文（createOrder）
 '''
+
+
 # 正常系１
 #   ＜発行体＞新規発行 -> ＜投資家＞Make注文（買）
 def test_createorder_normal_1(web3, chain, users, membership_exchange):
@@ -103,8 +120,8 @@ def test_createorder_normal_1(web3, chain, users, membership_exchange):
         trader, _amount, _price, _isBuy, agent
     )
 
-    order_id = membership_exchange.call().latestOrderId() - 1
-    orderbook = membership_exchange.call().orderBook(order_id)
+    order_id = membership_exchange.call().latestOrderId()
+    orderbook = membership_exchange.call().getOrder(order_id)
 
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
@@ -112,6 +129,7 @@ def test_createorder_normal_1(web3, chain, users, membership_exchange):
     ]
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
     assert membership_token.call().balanceOf(trader) == 0
+
 
 # 正常系2
 #   ＜発行体＞新規発行 -> ＜発行体＞Make注文（売）
@@ -141,10 +159,10 @@ def test_createorder_normal_2(web3, chain, users, membership_exchange):
         issuer, _amount, _price, _isBuy, agent
     )
 
-    order_id = membership_exchange.call().latestOrderId() - 1
-    orderbook = membership_exchange.call().orderBook(order_id)
-    issuer_commitment = membership_exchange.call().\
-        commitments(issuer, membership_token.address)
+    order_id = membership_exchange.call().latestOrderId()
+    orderbook = membership_exchange.call().getOrder(order_id)
+    issuer_commitment = membership_exchange.call(). \
+        commitmentOf(issuer, membership_token.address)
     issuer_balance = membership_token.call().balanceOf(issuer)
 
     assert orderbook == [
@@ -153,6 +171,7 @@ def test_createorder_normal_2(web3, chain, users, membership_exchange):
     ]
     assert issuer_balance == deploy_args[2] - _amount
     assert issuer_commitment == _amount
+
 
 # 正常系3-1
 #   限界値（買注文）
@@ -164,11 +183,11 @@ def test_createorder_normal_3_1(web3, chain, users, membership_exchange):
     # 新規発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1
+    deploy_args[2] = 2 ** 256 - 1
     membership_token = deploy(chain, deploy_args)
 
     # Make注文（買）
-    _amount = 2**256 - 1
+    _amount = 2 ** 256 - 1
     _price = 123
     _isBuy = True
     make_order(
@@ -177,8 +196,8 @@ def test_createorder_normal_3_1(web3, chain, users, membership_exchange):
         trader, _amount, _price, _isBuy, agent
     )
 
-    order_id = membership_exchange.call().latestOrderId() - 1
-    orderbook = membership_exchange.call().orderBook(order_id)
+    order_id = membership_exchange.call().latestOrderId()
+    orderbook = membership_exchange.call().getOrder(order_id)
 
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
@@ -186,6 +205,7 @@ def test_createorder_normal_3_1(web3, chain, users, membership_exchange):
     ]
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
     assert membership_token.call().balanceOf(trader) == 0
+
 
 # 正常系3-2
 #   限界値（売注文）
@@ -196,11 +216,11 @@ def test_createorder_normal_3_2(web3, chain, users, membership_exchange):
     # 新規発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1
+    deploy_args[2] = 2 ** 256 - 1
     membership_token = deploy(chain, deploy_args)
 
     # Exchangeへのデポジット
-    _amount = 2**256 - 1
+    _amount = 2 ** 256 - 1
     deposit(
         web3, chain,
         membership_token, membership_exchange,
@@ -208,7 +228,7 @@ def test_createorder_normal_3_2(web3, chain, users, membership_exchange):
     )
 
     # Make注文（売）
-    _price = 2**256 - 1
+    _price = 2 ** 256 - 1
     _isBuy = False
     make_order(
         web3, chain,
@@ -216,10 +236,10 @@ def test_createorder_normal_3_2(web3, chain, users, membership_exchange):
         issuer, _amount, _price, _isBuy, agent
     )
 
-    order_id = membership_exchange.call().latestOrderId() - 1
-    orderbook = membership_exchange.call().orderBook(order_id)
-    issuer_commitment = membership_exchange.call().\
-        commitments(issuer, membership_token.address)
+    order_id = membership_exchange.call().latestOrderId()
+    orderbook = membership_exchange.call().getOrder(order_id)
+    issuer_commitment = membership_exchange.call(). \
+        commitmentOf(issuer, membership_token.address)
     issuer_balance = membership_token.call().balanceOf(issuer)
 
     assert orderbook == [
@@ -229,10 +249,10 @@ def test_createorder_normal_3_2(web3, chain, users, membership_exchange):
     assert issuer_balance == deploy_args[2] - _amount
     assert issuer_commitment == _amount
 
+
 # エラー系1
 #   入力値の型誤り（_token）
-def test_createorder_error_1(web3, chain, users, membership_exchange):
-    issuer = users['issuer']
+def test_createorder_error_1(web3, users, membership_exchange):
     agent = users['agent']
 
     # Make注文
@@ -245,6 +265,7 @@ def test_createorder_error_1(web3, chain, users, membership_exchange):
 
     with pytest.raises(TypeError):
         membership_exchange.transact().createOrder(1234, _amount, _price, _isBuy, agent)
+
 
 # エラー系2
 #   入力値の型誤り（_amount）
@@ -268,7 +289,7 @@ def test_createorder_error_2(web3, chain, users, membership_exchange):
 
     with pytest.raises(TypeError):
         membership_exchange.transact().createOrder(
-            membership_token.address, 2**256, _price, _isBuy, agent)
+            membership_token.address, 2 ** 256, _price, _isBuy, agent)
 
     with pytest.raises(TypeError):
         membership_exchange.transact().createOrder(
@@ -277,6 +298,7 @@ def test_createorder_error_2(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_exchange.transact().createOrder(
             membership_token.address, 0.1, _price, _isBuy, agent)
+
 
 # エラー系3
 #   入力値の型誤り（_price）
@@ -300,7 +322,7 @@ def test_createorder_error_3(web3, chain, users, membership_exchange):
 
     with pytest.raises(TypeError):
         membership_exchange.transact().createOrder(
-            membership_token.address, _amount, 2**256, _isBuy, agent)
+            membership_token.address, _amount, 2 ** 256, _isBuy, agent)
 
     with pytest.raises(TypeError):
         membership_exchange.transact().createOrder(
@@ -309,6 +331,7 @@ def test_createorder_error_3(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_exchange.transact().createOrder(
             membership_token.address, _amount, 0.1, _isBuy, agent)
+
 
 # エラー系4
 #   入力値の型誤り（_isBuy）
@@ -334,6 +357,7 @@ def test_createorder_error_4(web3, chain, users, membership_exchange):
         membership_exchange.transact().createOrder(
             membership_token.address, _amount, _price, 'True', agent)
 
+
 # エラー系5
 #   入力値の型誤り（_agent）
 def test_createorder_error_5(web3, chain, users, membership_exchange):
@@ -358,6 +382,7 @@ def test_createorder_error_5(web3, chain, users, membership_exchange):
         membership_exchange.transact().createOrder(
             membership_token.address, _amount, _price, _isBuy, 1234)
 
+
 # エラー系6-1
 #   買注文に対するチェック
 #   1) 注文数量が0の場合
@@ -380,15 +405,16 @@ def test_createorder_error_6_1(web3, chain, users, membership_exchange):
         web3, chain,
         membership_token, membership_exchange,
         trader, _amount, _price, _isBuy, agent
-    ) # エラーになる
+    )  # エラーになる
     order_id_after = membership_exchange.call().latestOrderId()
 
-    trader_commitment = membership_exchange.call().\
-        commitments(trader, membership_token.address)
+    trader_commitment = membership_exchange.call(). \
+        commitmentOf(trader, membership_token.address)
     assert trader_commitment == 0
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
     assert membership_token.call().balanceOf(trader) == 0
     assert order_id_before == order_id_after
+
 
 # エラー系6-2
 #   買注文に対するチェック
@@ -418,15 +444,16 @@ def test_createorder_error_6_2(web3, chain, users, membership_exchange):
         web3, chain,
         membership_token, membership_exchange,
         trader, _amount, _price, _isBuy, agent
-    ) # エラーになる
+    )  # エラーになる
     order_id_after = membership_exchange.call().latestOrderId()
 
-    trader_commitment = membership_exchange.call().\
-        commitments(trader, membership_token.address)
+    trader_commitment = membership_exchange.call(). \
+        commitmentOf(trader, membership_token.address)
     assert trader_commitment == 0
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
     assert membership_token.call().balanceOf(trader) == 0
     assert order_id_before == order_id_after
+
 
 # エラー系6-3
 #   買注文に対するチェック
@@ -450,16 +477,17 @@ def test_createorder_error_6_3(web3, chain, users, membership_exchange):
         web3, chain,
         membership_token, membership_exchange,
         trader, _amount, _price, _isBuy, invalid_agent
-    ) # エラーになる
+    )  # エラーになる
 
     order_id_after = membership_exchange.call().latestOrderId()
-    trader_commitment = membership_exchange.call().\
-        commitments(trader, membership_token.address)
+    trader_commitment = membership_exchange.call(). \
+        commitmentOf(trader, membership_token.address)
 
     assert trader_commitment == 0
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
     assert membership_token.call().balanceOf(trader) == 0
     assert order_id_before == order_id_after
+
 
 # エラー系7-1
 #   売注文に対するチェック
@@ -490,12 +518,13 @@ def test_createorder_error_7_1(web3, chain, users, membership_exchange):
         web3, chain,
         membership_token, membership_exchange,
         issuer, _amount, _price, _isBuy, agent
-    ) # エラーになる
+    )  # エラーになる
 
-    issuer_commitment = membership_exchange.call().\
-        commitments(issuer, membership_token.address)
+    issuer_commitment = membership_exchange.call(). \
+        commitmentOf(issuer, membership_token.address)
     assert issuer_commitment == 0
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
+
 
 # エラー系7-2
 #   売注文に対するチェック
@@ -526,12 +555,13 @@ def test_createorder_error_7_2(web3, chain, users, membership_exchange):
         web3, chain,
         membership_token, membership_exchange,
         issuer, _amount, _price, _isBuy, agent
-    ) # エラーになる
+    )  # エラーになる
 
-    issuer_commitment = membership_exchange.call().\
-        commitments(issuer, membership_token.address)
+    issuer_commitment = membership_exchange.call(). \
+        commitmentOf(issuer, membership_token.address)
     assert issuer_commitment == 0
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
+
 
 # エラー系7-3
 #   売注文に対するチェック
@@ -568,12 +598,13 @@ def test_createorder_error_7_3(web3, chain, users, membership_exchange):
         web3, chain,
         membership_token, membership_exchange,
         issuer, _amount, _price, _isBuy, agent
-    ) # エラーになる
+    )  # エラーになる
 
-    issuer_commitment = membership_exchange.call().\
-        commitments(issuer, membership_token.address)
+    issuer_commitment = membership_exchange.call(). \
+        commitmentOf(issuer, membership_token.address)
     assert issuer_commitment == 0
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
+
 
 # エラー系7-4
 #   売注文に対するチェック
@@ -604,16 +635,19 @@ def test_createorder_error_7_4(web3, chain, users, membership_exchange):
         web3, chain,
         membership_token, membership_exchange,
         issuer, _amount, _price, _isBuy, invalid_agent
-    ) # エラーになる
+    )  # エラーになる
 
-    issuer_commitment = membership_exchange.call().\
-        commitments(issuer, membership_token.address)
+    issuer_commitment = membership_exchange.call(). \
+        commitmentOf(issuer, membership_token.address)
     assert issuer_commitment == 0
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
+
 
 '''
 TEST3_注文キャンセル（cancelOrder）
 '''
+
+
 # 正常系１
 #   ＜発行体＞新規発行 -> ＜投資家＞Make注文（買）
 #       -> ＜投資家＞注文キャンセル
@@ -638,18 +672,19 @@ def test_cancelorder_normal_1(web3, chain, users, membership_exchange):
     )
 
     # 注文キャンセル
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     chain.wait.for_receipt(
         membership_exchange.transact().cancelOrder(order_id)
     )
 
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         _amount, _price, _isBuy, agent, True
     ]
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
     assert membership_token.call().balanceOf(trader) == 0
+
 
 # 正常系2
 #   ＜発行体＞新規発行 -> ＜発行体＞Make注文（売）
@@ -682,19 +717,19 @@ def test_cancelorder_normal_2(web3, chain, users, membership_exchange):
     )
 
     # 注文キャンセル
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     chain.wait.for_receipt(
         membership_exchange.transact().cancelOrder(order_id)
     )
 
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         _amount, _price, _isBuy, agent, True
     ]
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
+
 
 # 正常系3-1
 #   限界値（買注文）
@@ -706,11 +741,11 @@ def test_cancelorder_normal_3_1(web3, chain, users, membership_exchange):
     # 新規発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1
+    deploy_args[2] = 2 ** 256 - 1
     membership_token = deploy(chain, deploy_args)
 
     # Make注文（買）
-    _amount = 2**256 - 1
+    _amount = 2 ** 256 - 1
     _price = 123
     _isBuy = True
     make_order(
@@ -720,17 +755,18 @@ def test_cancelorder_normal_3_1(web3, chain, users, membership_exchange):
     )
 
     # 注文キャンセル
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     chain.wait.for_receipt(
         membership_exchange.transact().cancelOrder(order_id)
     )
 
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         _amount, _price, _isBuy, agent, True
     ]
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
+
 
 # 正常系3-2
 #   限界値（売注文）
@@ -741,11 +777,11 @@ def test_cancelorder_normal_3_2(web3, chain, users, membership_exchange):
     # 新規発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1
+    deploy_args[2] = 2 ** 256 - 1
     membership_token = deploy(chain, deploy_args)
 
     # Exchangeへのデポジット
-    _amount = 2**256 - 1
+    _amount = 2 ** 256 - 1
     deposit(
         web3, chain,
         membership_token, membership_exchange,
@@ -753,7 +789,7 @@ def test_cancelorder_normal_3_2(web3, chain, users, membership_exchange):
     )
 
     # Make注文（売）
-    _price = 2**256 - 1
+    _price = 2 ** 256 - 1
     _isBuy = False
     make_order(
         web3, chain,
@@ -762,14 +798,14 @@ def test_cancelorder_normal_3_2(web3, chain, users, membership_exchange):
     )
 
     # 注文キャンセル
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     chain.wait.for_receipt(
         membership_exchange.transact().cancelOrder(order_id)
     )
 
-    orderbook = membership_exchange.call().orderBook(order_id)
-    issuer_commitment = membership_exchange.call().\
-        commitments(issuer, membership_token.address)
+    orderbook = membership_exchange.call().getOrder(order_id)
+    issuer_commitment = membership_exchange.call(). \
+        commitmentOf(issuer, membership_token.address)
     issuer_balance = membership_token.call().balanceOf(issuer)
 
     assert orderbook == [
@@ -778,6 +814,7 @@ def test_cancelorder_normal_3_2(web3, chain, users, membership_exchange):
     ]
     assert issuer_balance == deploy_args[2]
     assert issuer_commitment == 0
+
 
 # エラー系1
 #   入力値の型誤り（_orderId）
@@ -791,13 +828,14 @@ def test_cancelorder_error_1(web3, users, membership_exchange):
         membership_exchange.transact().cancelOrder(-1)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().cancelOrder(2**256)
+        membership_exchange.transact().cancelOrder(2 ** 256)
 
     with pytest.raises(TypeError):
         membership_exchange.transact().cancelOrder('0')
 
     with pytest.raises(TypeError):
         membership_exchange.transact().cancelOrder(0.1)
+
 
 # エラー系2
 #   指定した注文番号が、直近の注文ID以上の場合
@@ -829,23 +867,20 @@ def test_cancelorder_error_2(web3, chain, users, membership_exchange):
     )
 
     # 注文キャンセル：エラー
-    wrong_order_id = membership_exchange.call().\
-        latestOrderId() # 誤った order_id
-    correct_order_id = membership_exchange.call().\
-        latestOrderId() - 1 # 正しい order_id
+    wrong_order_id = membership_exchange.call().latestOrderId() + 1  # 誤った order_id
+    correct_order_id = membership_exchange.call().latestOrderId()  # 正しい order_id
     chain.wait.for_receipt(
         membership_exchange.transact().cancelOrder(wrong_order_id)
-    ) # エラーになる
+    )  # エラーになる
 
-    orderbook = membership_exchange.call().orderBook(correct_order_id)
+    orderbook = membership_exchange.call().getOrder(correct_order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         _amount, _price, _isBuy, agent, False
     ]
-    assert membership_token.call().balanceOf(issuer) == \
-        deploy_args[2] - _amount
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == _amount
+    assert membership_token.call().balanceOf(issuer) == deploy_args[2] - _amount
+    assert membership_exchange.call(). commitmentOf(issuer, membership_token.address) == _amount
+
 
 # エラー系3-1
 #   1) 元注文の残注文数量が0の場合
@@ -872,7 +907,7 @@ def test_cancelorder_error_3_1(web3, chain, users, membership_exchange):
         membership_token, membership_exchange,
         issuer, 100
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -880,7 +915,7 @@ def test_cancelorder_error_3_1(web3, chain, users, membership_exchange):
     )
 
     # 決済承認
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement(
         web3, chain,
         membership_token, membership_exchange,
@@ -890,15 +925,16 @@ def test_cancelorder_error_3_1(web3, chain, users, membership_exchange):
     # 注文キャンセル：エラー
     chain.wait.for_receipt(
         membership_exchange.transact().cancelOrder(order_id)
-    ) # エラーになる
+    )  # エラーになる
 
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         0, 123, True, agent, False
     ]
     assert membership_token.call().balanceOf(issuer) == deploy_args[2] - 100
     assert membership_token.call().balanceOf(trader) == 100
+
 
 # エラー系3-2
 #   2) 注文がキャンセル済みの場合
@@ -921,7 +957,7 @@ def test_cancelorder_error_3_2(web3, chain, users, membership_exchange):
 
     # 注文キャンセル１回目：正常
     web3.eth.defaultAccount = trader
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     chain.wait.for_receipt(
         membership_exchange.transact().cancelOrder(order_id)
     )
@@ -929,15 +965,16 @@ def test_cancelorder_error_3_2(web3, chain, users, membership_exchange):
     # 注文キャンセル２回目：エラー
     chain.wait.for_receipt(
         membership_exchange.transact().cancelOrder(order_id)
-    ) # エラーになる
+    )  # エラーになる
 
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         100, 123, True, agent, True
     ]
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
     assert membership_token.call().balanceOf(trader) == 0
+
 
 # エラー系3-3-1
 #   3) 元注文の発注者と、注文キャンセルの実施者が異なる場合
@@ -960,19 +997,20 @@ def test_cancelorder_error_3_3_1(web3, chain, users, membership_exchange):
     )
 
     # 注文キャンセル：エラー
-    web3.eth.defaultAccount = issuer # 注文実施者と異なる
-    order_id = membership_exchange.call().latestOrderId() - 1
+    web3.eth.defaultAccount = issuer  # 注文実施者と異なる
+    order_id = membership_exchange.call().latestOrderId()
     chain.wait.for_receipt(
         membership_exchange.transact().cancelOrder(order_id)
-    ) # エラーになる
+    )  # エラーになる
 
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         100, 123, True, agent, False
     ]
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
     assert membership_token.call().balanceOf(trader) == 0
+
 
 # エラー系3-3-2
 #   3) 元注文の発注者と、注文キャンセルの実施者が異なる場合
@@ -1002,24 +1040,26 @@ def test_cancelorder_error_3_3_2(web3, chain, users, membership_exchange):
     )
 
     # 注文キャンセル：エラー
-    web3.eth.defaultAccount = trader # 注文実施者と異なる
-    order_id = membership_exchange.call().latestOrderId() - 1
+    web3.eth.defaultAccount = trader  # 注文実施者と異なる
+    order_id = membership_exchange.call().latestOrderId()
     chain.wait.for_receipt(
         membership_exchange.transact().cancelOrder(order_id)
-    ) # エラーになる
+    )  # エラーになる
 
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         100, 123, False, agent, False
     ]
     assert membership_token.call().balanceOf(issuer) == deploy_args[2] - 100
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
+
 
 '''
 TEST4_Take注文（executeOrder）
 '''
+
+
 # 正常系1
 #   ＜発行体＞新規発行 -> ＜発行体＞Make注文（売）
 #       -> ＜投資家＞Take注文（買）
@@ -1046,7 +1086,7 @@ def test_executeOrder_normal_1(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -1054,7 +1094,7 @@ def test_executeOrder_normal_1(web3, chain, users, membership_exchange):
     )
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -1065,19 +1105,18 @@ def test_executeOrder_normal_1(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: agreement
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, False, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # 正常系2
 #   ＜発行体＞新規発行 -> ＜投資家＞Make注文（買）
@@ -1105,7 +1144,7 @@ def test_executeOrder_normal_2(web3, chain, users, membership_exchange):
         membership_token, membership_exchange,
         issuer, 50
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -1113,7 +1152,7 @@ def test_executeOrder_normal_2(web3, chain, users, membership_exchange):
     )
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         70, 123, True, agent, False
@@ -1124,19 +1163,18 @@ def test_executeOrder_normal_2(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 30
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 30
 
     # Assert: agreement
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         issuer, 30, 123, False, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # 正常系3-1
 #   限界値（買注文）
@@ -1148,34 +1186,34 @@ def test_executeOrder_normal_3_1(web3, chain, users, membership_exchange):
     # 新規発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1
+    deploy_args[2] = 2 ** 256 - 1
     membership_token = deploy(chain, deploy_args)
 
     # Make注文（売）
     deposit(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, 2**256 - 1
+        issuer, 2 ** 256 - 1
     )
     make_order(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, 2**256 - 1, 2**256 - 1, False, agent
+        issuer, 2 ** 256 - 1, 2 ** 256 - 1, False, agent
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        trader, order_id, 2**256 - 1, True
+        trader, order_id, 2 ** 256 - 1, True
     )
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
-        0, 2**256 - 1, False, agent, False
+        0, 2 ** 256 - 1, False, agent, False
     ]
 
     # Assert: balance
@@ -1183,19 +1221,18 @@ def test_executeOrder_normal_3_1(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 2**256 - 1
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 2 ** 256 - 1
 
     # Assert: agreement
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
-        trader, 2**256 - 1, 2**256 - 1, False, False
+        trader, 2 ** 256 - 1, 2 ** 256 - 1, False, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 2**256 - 1
+    assert membership_exchange.call().lastPrice(membership_token.address) == 2 ** 256 - 1
+
 
 # 正常系3-2
 #   限界値（売注文）
@@ -1207,34 +1244,34 @@ def test_executeOrder_normal_3_2(web3, chain, users, membership_exchange):
     # 新規発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1
+    deploy_args[2] = 2 ** 256 - 1
     membership_token = deploy(chain, deploy_args)
 
     # Make注文（買）
     make_order(
         web3, chain,
         membership_token, membership_exchange,
-        trader, 2**256 - 1, 2**256 - 1, True, agent
+        trader, 2 ** 256 - 1, 2 ** 256 - 1, True, agent
     )
 
     # Take注文（売）
     deposit(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, 2**256 - 1
+        issuer, 2 ** 256 - 1
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, order_id, 2**256 - 1, False
+        issuer, order_id, 2 ** 256 - 1, False
     )
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
-        0, 2**256 - 1, True, agent, False
+        0, 2 ** 256 - 1, True, agent, False
     ]
 
     # Assert: balance
@@ -1242,19 +1279,18 @@ def test_executeOrder_normal_3_2(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 2**256 - 1
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 2 ** 256 - 1
 
     # Assert: agreement
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
-        issuer, 2**256 - 1, 2**256 - 1, False, False
+        issuer, 2 ** 256 - 1, 2 ** 256 - 1, False, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 2**256 - 1
+    assert membership_exchange.call().lastPrice(membership_token.address) == 2 ** 256 - 1
+
 
 # エラー系1
 #   入力値の型誤り（orderId）
@@ -1269,13 +1305,14 @@ def test_executeOrder_error_1(web3, users, membership_exchange):
         membership_exchange.transact().executeOrder(-1, amount, is_buy)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().executeOrder(2**256, amount, is_buy)
+        membership_exchange.transact().executeOrder(2 ** 256, amount, is_buy)
 
     with pytest.raises(TypeError):
         membership_exchange.transact().executeOrder('0', amount, is_buy)
 
     with pytest.raises(TypeError):
         membership_exchange.transact().executeOrder(0.1, amount, is_buy)
+
 
 # エラー系2
 #   入力値の型誤り（amount）
@@ -1290,13 +1327,14 @@ def test_executeOrder_error_2(web3, users, membership_exchange):
         membership_exchange.transact().executeOrder(order_id, -1, is_buy)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().executeOrder(order_id, 2**256, is_buy)
+        membership_exchange.transact().executeOrder(order_id, 2 ** 256, is_buy)
 
     with pytest.raises(TypeError):
         membership_exchange.transact().executeOrder(order_id, '0', is_buy)
 
     with pytest.raises(TypeError):
         membership_exchange.transact().executeOrder(order_id, 0.1, is_buy)
+
 
 # エラー系3
 #   入力値の型誤り（isBuy）
@@ -1312,6 +1350,7 @@ def test_executeOrder_error_3(web3, users, membership_exchange):
 
     with pytest.raises(TypeError):
         membership_exchange.transact().executeOrder(order_id, amount, 111)
+
 
 # エラー系4
 #   指定した注文IDが直近の注文IDを超えている場合
@@ -1338,16 +1377,16 @@ def test_executeOrder_error_4(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）：エラー
-    wrong_order_id = membership_exchange.call().latestOrderId() # 誤ったID
-    correct_order_id = membership_exchange.call().latestOrderId() - 1 # 正しいID
+    wrong_order_id = membership_exchange.call().latestOrderId() + 1  # 誤ったID
+    correct_order_id = membership_exchange.call().latestOrderId()  # 正しいID
     take_order(
         web3, chain,
         membership_token, membership_exchange,
         trader, wrong_order_id, 30, True
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(correct_order_id)
+    orderbook = membership_exchange.call().getOrder(correct_order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         100, 123, False, agent, False
@@ -1358,12 +1397,11 @@ def test_executeOrder_error_4(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系5-1
 #   Take買注文
@@ -1391,15 +1429,15 @@ def test_executeOrder_error_5_1(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）：エラー
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        trader, order_id, 0, True # 注文数量が0
-    ) # エラーになる
+        trader, order_id, 0, True  # 注文数量が0
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         100, 123, False, agent, False
@@ -1410,12 +1448,11 @@ def test_executeOrder_error_5_1(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系5-2
 #   Take買注文
@@ -1438,15 +1475,15 @@ def test_executeOrder_error_5_2(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）：エラー
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        trader, order_id, 30, True # 同一売買区分
-    ) # エラーになる
+        trader, order_id, 30, True  # 同一売買区分
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         100, 123, True, agent, False
@@ -1457,12 +1494,11 @@ def test_executeOrder_error_5_2(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系5-3
 #   Take買注文
@@ -1489,15 +1525,15 @@ def test_executeOrder_error_5_3(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）：エラー
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, order_id, 30, True # 同一アドレスからの発注
-    ) # エラーになる
+        issuer, order_id, 30, True  # 同一アドレスからの発注
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         100, 123, False, agent, False
@@ -1507,12 +1543,11 @@ def test_executeOrder_error_5_3(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(issuer) == deploy_args[2] - 100
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系5-4
 #   Take買注文
@@ -1541,21 +1576,21 @@ def test_executeOrder_error_5_4(web3, chain, users, membership_exchange):
 
     # Make注文のキャンセル
     web3.eth.defaultAccount = issuer
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     chain.wait.for_receipt(
         membership_exchange.transact().cancelOrder(order_id)
     )
 
     # Take注文（買）：エラー
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
         trader, order_id, 30, True
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         100, 123, False, agent, True
@@ -1566,12 +1601,11 @@ def test_executeOrder_error_5_4(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系5-5
 #   Take買注文
@@ -1605,15 +1639,15 @@ def test_executeOrder_error_5_5(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）：エラー
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
         trader, order_id, 30, True
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         100, 123, False, agent, False
@@ -1624,12 +1658,11 @@ def test_executeOrder_error_5_5(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系5-6
 #   Take買注文
@@ -1657,15 +1690,15 @@ def test_executeOrder_error_5_6(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）：エラー
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        trader, order_id, 101, True # Make注文の数量を超過
-    ) # エラーになる
+        trader, order_id, 101, True  # Make注文の数量を超過
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         100, 123, False, agent, False
@@ -1676,12 +1709,11 @@ def test_executeOrder_error_5_6(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系6-1
 #   Take売注文
@@ -1709,15 +1741,15 @@ def test_executeOrder_error_6_1(web3, chain, users, membership_exchange):
         membership_token, membership_exchange,
         issuer, 50
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, order_id, 0, False # 注文数量が0
-    ) # エラーになる
+        issuer, order_id, 0, False  # 注文数量が0
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         100, 123, True, agent, False
@@ -1728,12 +1760,11 @@ def test_executeOrder_error_6_1(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系6-2
 #   Take売注文
@@ -1761,15 +1792,15 @@ def test_executeOrder_error_6_2(web3, chain, users, membership_exchange):
     )
 
     # Take注文（売）：エラー
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        trader, order_id, 30, False # 同一売買区分
-    ) # エラーになる
+        trader, order_id, 30, False  # 同一売買区分
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         100, 123, False, agent, False
@@ -1780,12 +1811,11 @@ def test_executeOrder_error_6_2(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系6-3
 #   Take売注文
@@ -1813,15 +1843,15 @@ def test_executeOrder_error_6_3(web3, chain, users, membership_exchange):
         membership_token, membership_exchange,
         issuer, 50
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, order_id, 30, False # Make注文と同一アドレスからの発注
-    ) # エラーになる
+        issuer, order_id, 30, False  # Make注文と同一アドレスからの発注
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         100, 123, True, agent, False
@@ -1832,12 +1862,11 @@ def test_executeOrder_error_6_3(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系6-4
 #   Take売注文
@@ -1861,7 +1890,7 @@ def test_executeOrder_error_6_4(web3, chain, users, membership_exchange):
 
     # Make注文のキャンセル
     web3.eth.defaultAccount = trader
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     chain.wait.for_receipt(
         membership_exchange.transact().cancelOrder(order_id)
     )
@@ -1872,15 +1901,15 @@ def test_executeOrder_error_6_4(web3, chain, users, membership_exchange):
         membership_token, membership_exchange,
         issuer, 50
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
         issuer, order_id, 30, False
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         100, 123, True, agent, True
@@ -1891,12 +1920,11 @@ def test_executeOrder_error_6_4(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系6-5
 #   Take売注文
@@ -1930,15 +1958,15 @@ def test_executeOrder_error_6_5(web3, chain, users, membership_exchange):
         membership_token, membership_exchange,
         issuer, 50
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
         issuer, order_id, 30, False
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         100, 123, True, agent, False
@@ -1949,12 +1977,11 @@ def test_executeOrder_error_6_5(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系6-6
 #   Take売注文
@@ -1982,15 +2009,15 @@ def test_executeOrder_error_6_6(web3, chain, users, membership_exchange):
         membership_token, membership_exchange,
         issuer, 50
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, order_id, 51, False # balanceを超える注文数量
-    ) # エラーになる
+        issuer, order_id, 51, False  # balanceを超える注文数量
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         100, 123, True, agent, False
@@ -2001,12 +2028,11 @@ def test_executeOrder_error_6_6(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 # エラー系6-7
 #   Take売注文
@@ -2034,15 +2060,15 @@ def test_executeOrder_error_6_7(web3, chain, users, membership_exchange):
         membership_token, membership_exchange,
         issuer, 101
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
         issuer, order_id, 101, False
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         100, 123, True, agent, False
@@ -2053,16 +2079,17 @@ def test_executeOrder_error_6_7(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 0
+    assert membership_exchange.call().lastPrice(membership_token.address) == 0
+
 
 '''
 TEST5_決済承認（confirmAgreement）
 '''
+
+
 # 正常系1
 #   Make売、Take買
 #       ＜発行体＞新規発行 -> ＜発行体＞Make注文（売）
@@ -2090,7 +2117,7 @@ def test_confirmAgreement_normal_1(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -2098,7 +2125,7 @@ def test_confirmAgreement_normal_1(web3, chain, users, membership_exchange):
     )
 
     # 決済処理
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement(
         web3, chain,
         membership_token, membership_exchange,
@@ -2106,7 +2133,7 @@ def test_confirmAgreement_normal_1(web3, chain, users, membership_exchange):
     )
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -2117,18 +2144,17 @@ def test_confirmAgreement_normal_1(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 30
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 70
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 70
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, False, True
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # 正常系2
 #   Make買、Take売
@@ -2157,7 +2183,7 @@ def test_confirmAgreement_normal_2(web3, chain, users, membership_exchange):
         membership_token, membership_exchange,
         issuer, 50
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -2165,7 +2191,7 @@ def test_confirmAgreement_normal_2(web3, chain, users, membership_exchange):
     )
 
     # 決済処理
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement(
         web3, chain,
         membership_token, membership_exchange,
@@ -2173,7 +2199,7 @@ def test_confirmAgreement_normal_2(web3, chain, users, membership_exchange):
     )
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         70, 123, True, agent, False
@@ -2184,18 +2210,17 @@ def test_confirmAgreement_normal_2(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 30
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         issuer, 30, 123, False, True
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # 正常系3-1
 #   Make売、Take買
@@ -2208,31 +2233,31 @@ def test_confirmAgreement_normal_3_1(web3, chain, users, membership_exchange):
     # 新規発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1 #上限値
+    deploy_args[2] = 2 ** 256 - 1  # 上限値
     membership_token = deploy(chain, deploy_args)
 
     # Make注文（売）
     deposit(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, 2**256 - 1
+        issuer, 2 ** 256 - 1
     )
     make_order(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, 2**256 - 1, 2**256 - 1, False, agent
+        issuer, 2 ** 256 - 1, 2 ** 256 - 1, False, agent
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        trader, order_id, 2**256 - 1, True
+        trader, order_id, 2 ** 256 - 1, True
     )
 
     # 決済処理
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement(
         web3, chain,
         membership_token, membership_exchange,
@@ -2240,29 +2265,28 @@ def test_confirmAgreement_normal_3_1(web3, chain, users, membership_exchange):
     )
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
-        0, 2**256 - 1, False, agent, False
+        0, 2 ** 256 - 1, False, agent, False
     ]
 
     # Assert: balance
     assert membership_token.call().balanceOf(issuer) == 0
-    assert membership_token.call().balanceOf(trader) == 2**256 - 1
+    assert membership_token.call().balanceOf(trader) == 2 ** 256 - 1
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
-        trader, 2**256 - 1, 2**256 - 1, False, True
+        trader, 2 ** 256 - 1, 2 ** 256 - 1, False, True
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 2**256 - 1
+    assert membership_exchange.call().lastPrice(membership_token.address) == 2 ** 256 - 1
+
 
 # 正常系3-2
 #   Make買、Take売
@@ -2275,31 +2299,31 @@ def test_confirmAgreement_normal_3_2(web3, chain, users, membership_exchange):
     # 新規発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1 #上限値
+    deploy_args[2] = 2 ** 256 - 1  # 上限値
     membership_token = deploy(chain, deploy_args)
 
     # Make注文（買）
     make_order(
         web3, chain,
         membership_token, membership_exchange,
-        trader, 2**256 - 1, 2**256 - 1, True, agent
+        trader, 2 ** 256 - 1, 2 ** 256 - 1, True, agent
     )
 
     # Take注文（売）
     deposit(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, 2**256 - 1
+        issuer, 2 ** 256 - 1
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, order_id, 2**256 - 1, False
+        issuer, order_id, 2 ** 256 - 1, False
     )
 
     # 決済処理
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement(
         web3, chain,
         membership_token, membership_exchange,
@@ -2307,29 +2331,28 @@ def test_confirmAgreement_normal_3_2(web3, chain, users, membership_exchange):
     )
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
-        0, 2**256 - 1, True, agent, False
+        0, 2 ** 256 - 1, True, agent, False
     ]
 
     # Assert: balance
     assert membership_token.call().balanceOf(issuer) == 0
-    assert membership_token.call().balanceOf(trader) == 2**256 - 1
+    assert membership_token.call().balanceOf(trader) == 2 ** 256 - 1
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
-        issuer, 2**256 - 1, 2**256 - 1, False, True
+        issuer, 2 ** 256 - 1, 2 ** 256 - 1, False, True
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 2**256 - 1
+    assert membership_exchange.call().lastPrice(membership_token.address) == 2 ** 256 - 1
+
 
 # エラー系1
 #   入力値の型誤り（orderId）
@@ -2340,16 +2363,17 @@ def test_confirmAgreement_error_1(web3, users, membership_exchange):
     web3.eth.defaultAccount = agent
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().confirmAgreement(-1,0)
+        membership_exchange.transact().confirmAgreement(-1, 0)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().confirmAgreement(2**256,0)
+        membership_exchange.transact().confirmAgreement(2 ** 256, 0)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().confirmAgreement('0',0)
+        membership_exchange.transact().confirmAgreement('0', 0)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().confirmAgreement(0.1,0)
+        membership_exchange.transact().confirmAgreement(0.1, 0)
+
 
 # エラー系2
 #   入力値の型誤り（agreementId）
@@ -2360,16 +2384,17 @@ def test_confirmAgreement_error_2(web3, users, membership_exchange):
     web3.eth.defaultAccount = agent
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().confirmAgreement(0,-1)
+        membership_exchange.transact().confirmAgreement(0, -1)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().confirmAgreement(0,2**256)
+        membership_exchange.transact().confirmAgreement(0, 2 ** 256)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().confirmAgreement(0,'0')
+        membership_exchange.transact().confirmAgreement(0, '0')
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().confirmAgreement(0,0.1)
+        membership_exchange.transact().confirmAgreement(0, 0.1)
+
 
 # エラー系3
 #   指定した注文番号が、直近の注文ID以上の場合
@@ -2396,7 +2421,7 @@ def test_confirmAgreement_error_3(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -2404,16 +2429,16 @@ def test_confirmAgreement_error_3(web3, chain, users, membership_exchange):
     )
 
     # 決済処理：エラー
-    wrong_order_id = membership_exchange.call().latestOrderId() # 誤ったID
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    wrong_order_id = membership_exchange.call().latestOrderId() + 1  # 誤ったID
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement(
         web3, chain,
         membership_token, membership_exchange,
         agent, wrong_order_id, agreement_id
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -2424,18 +2449,17 @@ def test_confirmAgreement_error_3(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, False, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # エラー系4
 #   指定した約定IDが、直近の約定ID以上の場合
@@ -2462,7 +2486,7 @@ def test_confirmAgreement_error_4(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -2470,17 +2494,16 @@ def test_confirmAgreement_error_4(web3, chain, users, membership_exchange):
     )
 
     # 決済処理：エラー
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
-    wrong_agreement_id = membership_exchange.call().\
-        latestAgreementIds(order_id) # 誤ったID
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
+    wrong_agreement_id = membership_exchange.call().latestAgreementId(order_id) + 1  # 誤ったID
     settlement(
         web3, chain,
         membership_token, membership_exchange,
         agent, order_id, wrong_agreement_id
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -2491,18 +2514,17 @@ def test_confirmAgreement_error_4(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, False, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # エラー系5
 #   すでに決済承認済み（支払い済み）の場合
@@ -2529,7 +2551,7 @@ def test_confirmAgreement_error_5(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -2537,7 +2559,7 @@ def test_confirmAgreement_error_5(web3, chain, users, membership_exchange):
     )
 
     # 決済処理1回目
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement(
         web3, chain,
         membership_token, membership_exchange,
@@ -2545,15 +2567,15 @@ def test_confirmAgreement_error_5(web3, chain, users, membership_exchange):
     )
 
     # 決済処理２回目：エラー
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement(
         web3, chain,
         membership_token, membership_exchange,
         agent, order_id, agreement_id
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -2564,18 +2586,17 @@ def test_confirmAgreement_error_5(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 30
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 70
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 70
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, False, True
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # エラー系6
 #   すでに決済非承認済み（キャンセル済み）の場合
@@ -2602,7 +2623,7 @@ def test_confirmAgreement_error_6(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -2610,7 +2631,7 @@ def test_confirmAgreement_error_6(web3, chain, users, membership_exchange):
     )
 
     # 決済非承認
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement_ng(
         web3, chain,
         membership_token, membership_exchange,
@@ -2618,15 +2639,15 @@ def test_confirmAgreement_error_6(web3, chain, users, membership_exchange):
     )
 
     # 決済処理：エラー
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement(
         web3, chain,
         membership_token, membership_exchange,
         agent, order_id, agreement_id
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -2637,18 +2658,17 @@ def test_confirmAgreement_error_6(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 70
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 70
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, True, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # エラー系7
 #   元注文で指定した決済業者ではない場合
@@ -2675,7 +2695,7 @@ def test_confirmAgreement_error_7(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -2683,15 +2703,15 @@ def test_confirmAgreement_error_7(web3, chain, users, membership_exchange):
     )
 
     # 決済処理：エラー
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement(
         web3, chain,
         membership_token, membership_exchange,
-        trader, order_id, agreement_id # 元注文で指定した決済業者ではない
-    ) # エラーになる
+        trader, order_id, agreement_id  # 元注文で指定した決済業者ではない
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -2702,22 +2722,23 @@ def test_confirmAgreement_error_7(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, False, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 '''
 TEST6_決済非承認（cancelAgreement）
 '''
+
+
 # 正常系1
 #   Make売、Take買
 #       ＜発行体＞新規発行 -> ＜発行体＞Make注文（売）
@@ -2745,7 +2766,7 @@ def test_cancelAgreement_normal_1(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -2753,7 +2774,7 @@ def test_cancelAgreement_normal_1(web3, chain, users, membership_exchange):
     )
 
     # 決済非承認
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement_ng(
         web3, chain,
         membership_token, membership_exchange,
@@ -2761,7 +2782,7 @@ def test_cancelAgreement_normal_1(web3, chain, users, membership_exchange):
     )
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -2772,18 +2793,17 @@ def test_cancelAgreement_normal_1(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 70
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 70
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, True, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # 正常系2
 #   Make買、Take売
@@ -2812,7 +2832,7 @@ def test_cancelAgreement_normal_2(web3, chain, users, membership_exchange):
         membership_token, membership_exchange,
         issuer, 50
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -2820,7 +2840,7 @@ def test_cancelAgreement_normal_2(web3, chain, users, membership_exchange):
     )
 
     # 決済非承認
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement_ng(
         web3, chain,
         membership_token, membership_exchange,
@@ -2828,7 +2848,7 @@ def test_cancelAgreement_normal_2(web3, chain, users, membership_exchange):
     )
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
         70, 123, True, agent, False
@@ -2839,18 +2859,17 @@ def test_cancelAgreement_normal_2(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         issuer, 30, 123, True, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # 正常系3-1
 #   Make売、Take買
@@ -2863,31 +2882,31 @@ def test_cancelAgreement_normal_3_1(web3, chain, users, membership_exchange):
     # 新規発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1 #上限値
+    deploy_args[2] = 2 ** 256 - 1  # 上限値
     membership_token = deploy(chain, deploy_args)
 
     # Make注文（売）
     deposit(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, 2**256 - 1
+        issuer, 2 ** 256 - 1
     )
     make_order(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, 2**256 - 1, 2**256 - 1, False, agent
+        issuer, 2 ** 256 - 1, 2 ** 256 - 1, False, agent
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        trader, order_id, 2**256 - 1, True
+        trader, order_id, 2 ** 256 - 1, True
     )
 
     # 決済非承認
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement_ng(
         web3, chain,
         membership_token, membership_exchange,
@@ -2895,10 +2914,10 @@ def test_cancelAgreement_normal_3_1(web3, chain, users, membership_exchange):
     )
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
-        0, 2**256 - 1, False, agent, False
+        0, 2 ** 256 - 1, False, agent, False
     ]
 
     # Assert: balance
@@ -2906,18 +2925,17 @@ def test_cancelAgreement_normal_3_1(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
-        trader, 2**256 - 1, 2**256 - 1, True, False
+        trader, 2 ** 256 - 1, 2 ** 256 - 1, True, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 2**256 - 1
+    assert membership_exchange.call().lastPrice(membership_token.address) == 2 ** 256 - 1
+
 
 # 正常系3-2
 #   Make買、Take売
@@ -2930,31 +2948,31 @@ def test_cancelAgreement_normal_3_2(web3, chain, users, membership_exchange):
     # 新規発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1 #上限値
+    deploy_args[2] = 2 ** 256 - 1  # 上限値
     membership_token = deploy(chain, deploy_args)
 
     # Make注文（買）
     make_order(
         web3, chain,
         membership_token, membership_exchange,
-        trader, 2**256 - 1, 2**256 - 1, True, agent
+        trader, 2 ** 256 - 1, 2 ** 256 - 1, True, agent
     )
 
     # Take注文（売）
     deposit(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, 2**256 - 1
+        issuer, 2 ** 256 - 1
     )
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, order_id, 2**256 - 1, False
+        issuer, order_id, 2 ** 256 - 1, False
     )
 
     # 決済非承認
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement_ng(
         web3, chain,
         membership_token, membership_exchange,
@@ -2962,10 +2980,10 @@ def test_cancelAgreement_normal_3_2(web3, chain, users, membership_exchange):
     )
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         trader, to_checksum_address(membership_token.address),
-        0, 2**256 - 1, True, agent, False
+        0, 2 ** 256 - 1, True, agent, False
     ]
 
     # Assert: balance
@@ -2973,18 +2991,17 @@ def test_cancelAgreement_normal_3_2(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 0
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 0
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
-        issuer, 2**256 - 1, 2**256 - 1, True, False
+        issuer, 2 ** 256 - 1, 2 ** 256 - 1, True, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 2**256 - 1
+    assert membership_exchange.call().lastPrice(membership_token.address) == 2 ** 256 - 1
+
 
 # エラー系1
 #   入力値の型誤り（orderId）
@@ -2998,13 +3015,14 @@ def test_cancelAgreement_error_1(web3, users, membership_exchange):
         membership_exchange.transact().cancelAgreement(-1, 0)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().cancelAgreement(2**256, 0)
+        membership_exchange.transact().cancelAgreement(2 ** 256, 0)
 
     with pytest.raises(TypeError):
         membership_exchange.transact().cancelAgreement('0', 0)
 
     with pytest.raises(TypeError):
         membership_exchange.transact().cancelAgreement(0.1, 0)
+
 
 # エラー系2
 #   入力値の型誤り（_agreementId）
@@ -3018,13 +3036,14 @@ def test_cancelAgreement_error_2(web3, users, membership_exchange):
         membership_exchange.transact().cancelAgreement(0, -1)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().cancelAgreement(0, 2**256)
+        membership_exchange.transact().cancelAgreement(0, 2 ** 256)
 
     with pytest.raises(TypeError):
         membership_exchange.transact().cancelAgreement(0, '0')
 
     with pytest.raises(TypeError):
         membership_exchange.transact().cancelAgreement(0, 0.1)
+
 
 # エラー系3
 #   指定した注文番号が、直近の注文ID以上の場合
@@ -3051,7 +3070,7 @@ def test_cancelAgreement_error_3(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -3059,16 +3078,16 @@ def test_cancelAgreement_error_3(web3, chain, users, membership_exchange):
     )
 
     # 決済非承認：エラー
-    wrong_order_id = membership_exchange.call().latestOrderId() # 誤ったID
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    wrong_order_id = membership_exchange.call().latestOrderId() + 1  # 誤ったID
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement_ng(
         web3, chain,
         membership_token, membership_exchange,
         agent, wrong_order_id, agreement_id
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -3079,18 +3098,17 @@ def test_cancelAgreement_error_3(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, False, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # エラー系4
 #   指定した約定IDが、直近の約定ID以上の場合
@@ -3117,7 +3135,7 @@ def test_cancelAgreement_error_4(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -3125,17 +3143,16 @@ def test_cancelAgreement_error_4(web3, chain, users, membership_exchange):
     )
 
     # 決済非承認：エラー
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
-    wrong_agreement_id = membership_exchange.call().\
-        latestAgreementIds(order_id) # 誤ったID
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
+    wrong_agreement_id = membership_exchange.call().latestAgreementId(order_id) + 1  # 誤ったID
     settlement_ng(
         web3, chain,
         membership_token, membership_exchange,
         agent, order_id, wrong_agreement_id
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -3146,18 +3163,17 @@ def test_cancelAgreement_error_4(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, False, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # エラー系5
 #   すでに決済承認済み（支払い済み）の場合
@@ -3184,7 +3200,7 @@ def test_cancelAgreement_error_5(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -3192,7 +3208,7 @@ def test_cancelAgreement_error_5(web3, chain, users, membership_exchange):
     )
 
     # 決済処理
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement(
         web3, chain,
         membership_token, membership_exchange,
@@ -3204,10 +3220,10 @@ def test_cancelAgreement_error_5(web3, chain, users, membership_exchange):
         web3, chain,
         membership_token, membership_exchange,
         agent, order_id, agreement_id
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -3218,18 +3234,17 @@ def test_cancelAgreement_error_5(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 30
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 70
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 70
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, False, True
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # エラー系6
 #   すでに決済非承認済み（キャンセル済み）の場合
@@ -3256,7 +3271,7 @@ def test_cancelAgreement_error_6(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -3264,7 +3279,7 @@ def test_cancelAgreement_error_6(web3, chain, users, membership_exchange):
     )
 
     # 決済非承認１回目
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement_ng(
         web3, chain,
         membership_token, membership_exchange,
@@ -3276,10 +3291,10 @@ def test_cancelAgreement_error_6(web3, chain, users, membership_exchange):
         web3, chain,
         membership_token, membership_exchange,
         agent, order_id, agreement_id
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -3290,18 +3305,17 @@ def test_cancelAgreement_error_6(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 70
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 70
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, True, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 # エラー系7
 #   元注文で指定した決済業者ではない場合
@@ -3328,7 +3342,7 @@ def test_cancelAgreement_error_7(web3, chain, users, membership_exchange):
     )
 
     # Take注文（買）
-    order_id = membership_exchange.call().latestOrderId() - 1
+    order_id = membership_exchange.call().latestOrderId()
     take_order(
         web3, chain,
         membership_token, membership_exchange,
@@ -3336,15 +3350,15 @@ def test_cancelAgreement_error_7(web3, chain, users, membership_exchange):
     )
 
     # 決済非承認１回目
-    agreement_id = membership_exchange.call().latestAgreementIds(order_id) - 1
+    agreement_id = membership_exchange.call().latestAgreementId(order_id)
     settlement_ng(
         web3, chain,
         membership_token, membership_exchange,
-        trader, order_id, agreement_id # 元注文で指定した決済業者ではない
-    ) # エラーになる
+        trader, order_id, agreement_id  # 元注文で指定した決済業者ではない
+    )  # エラーになる
 
     # Assert: orderbook
-    orderbook = membership_exchange.call().orderBook(order_id)
+    orderbook = membership_exchange.call().getOrder(order_id)
     assert orderbook == [
         issuer, to_checksum_address(membership_token.address),
         70, 123, False, agent, False
@@ -3355,22 +3369,23 @@ def test_cancelAgreement_error_7(web3, chain, users, membership_exchange):
     assert membership_token.call().balanceOf(trader) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 100
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 100
 
     # Assert: agreement
-    agreement = membership_exchange.call().agreements(order_id, agreement_id)
+    agreement = membership_exchange.call().getAgreement(order_id, agreement_id)
     assert agreement[0:5] == [
         trader, 30, 123, False, False
     ]
 
     # Assert: last_price
-    assert membership_exchange.call().\
-        lastPrice(membership_token.address) == 123
+    assert membership_exchange.call().lastPrice(membership_token.address) == 123
+
 
 '''
 TEST7_引き出し（withdrawAll）
 '''
+
+
 # 正常系1
 #   ＜発行体＞新規発行 -> ＜発行体＞デポジット
 #       -> ＜発行体＞引き出し
@@ -3397,8 +3412,8 @@ def test_withdrawAll_normal_1(web3, chain, users, membership_exchange):
 
     # Assert: balance
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
-    assert membership_exchange.call().\
-        balances(issuer, membership_token.address) == 0
+    assert membership_exchange.call().balanceOf(issuer, membership_token.address) == 0
+
 
 # 正常系2
 #   ＜発行体＞新規発行 -> ＜発行体＞デポジット（２回）
@@ -3433,8 +3448,8 @@ def test_withdrawAll_normal_2(web3, chain, users, membership_exchange):
 
     # Assert: balance
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
-    assert membership_exchange.call().\
-        balances(issuer, membership_token.address) == 0
+    assert membership_exchange.call().balanceOf(issuer, membership_token.address) == 0
+
 
 # 正常系3
 #   ＜発行体＞新規発行 -> ＜発行体＞デポジット
@@ -3470,12 +3485,11 @@ def test_withdrawAll_normal_3(web3, chain, users, membership_exchange):
 
     # Assert: balance
     assert membership_token.call().balanceOf(issuer) == deploy_args[2] - 70
-    assert membership_exchange.call().\
-        balances(issuer, membership_token.address) == 0
+    assert membership_exchange.call().balanceOf(issuer, membership_token.address) == 0
 
     # Assert: commitment
-    assert membership_exchange.call().\
-        commitments(issuer, membership_token.address) == 70
+    assert membership_exchange.call().commitmentOf(issuer, membership_token.address) == 70
+
 
 # 正常系4
 #   限界値
@@ -3485,14 +3499,14 @@ def test_withdrawAll_normal_4(web3, chain, users, membership_exchange):
     # 新規発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1
+    deploy_args[2] = 2 ** 256 - 1
     membership_token = deploy(chain, deploy_args)
 
     # デポジット
     deposit(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, 2**256 - 1
+        issuer, 2 ** 256 - 1
     )
 
     # 引き出し
@@ -3503,8 +3517,8 @@ def test_withdrawAll_normal_4(web3, chain, users, membership_exchange):
 
     # Assert: balance
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
-    assert membership_exchange.call().\
-        balances(issuer, membership_token.address) == 0
+    assert membership_exchange.call().balanceOf(issuer, membership_token.address) == 0
+
 
 # エラー系１
 #   入力値の型誤り（token）
@@ -3520,6 +3534,7 @@ def test_withdrawAll_error_1(web3, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_exchange.transact().withdrawAll('1234')
 
+
 # エラー系2
 #   残高がゼロの場合
 def test_withdrawAll_error_2(web3, chain, users, membership_exchange):
@@ -3534,16 +3549,18 @@ def test_withdrawAll_error_2(web3, chain, users, membership_exchange):
     web3.eth.defaultAccount = issuer
     chain.wait.for_receipt(
         membership_exchange.transact().withdrawAll(membership_token.address)
-    ) # エラーになる
+    )  # エラーになる
 
     # Assert: balance
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
-    assert membership_exchange.call().\
-        balances(issuer, membership_token.address) == 0
+    assert membership_exchange.call().balanceOf(issuer, membership_token.address) == 0
+
 
 '''
 TEST8_送信（transfer）
 '''
+
+
 # 正常系1
 #   ＜発行体＞新規発行 -> ＜発行体＞デポジット
 #       -> ＜発行体＞送信
@@ -3566,15 +3583,14 @@ def test_transfer_normal_1(web3, chain, users, membership_exchange):
     # 送信
     web3.eth.defaultAccount = issuer
     chain.wait.for_receipt(
-        membership_exchange.transact().\
-            transfer(membership_token.address, trader, 30)
+        membership_exchange.transact().transfer(membership_token.address, trader, 30)
     )
 
     # Assert: balance
     assert membership_token.call().balanceOf(issuer) == deploy_args[2] - 100
     assert membership_token.call().balanceOf(trader) == 30
-    assert membership_exchange.call().\
-        balances(issuer, membership_token.address) == 70
+    assert membership_exchange.call().balanceOf(issuer, membership_token.address) == 70
+
 
 # 正常系2
 #   限界値
@@ -3585,32 +3601,31 @@ def test_transfer_normal_2(web3, chain, users, membership_exchange):
     # 新規発行
     web3.eth.defaultAccount = issuer
     deploy_args = init_args(membership_exchange.address)
-    deploy_args[2] = 2**256 - 1
+    deploy_args[2] = 2 ** 256 - 1
     membership_token = deploy(chain, deploy_args)
 
     # デポジット
     deposit(
         web3, chain,
         membership_token, membership_exchange,
-        issuer, 2**256 - 1
+        issuer, 2 ** 256 - 1
     )
 
     # 送信
     web3.eth.defaultAccount = issuer
     chain.wait.for_receipt(
-        membership_exchange.transact().\
-            transfer(membership_token.address, trader, 2**256 - 1)
+        membership_exchange.transact().transfer(membership_token.address, trader, 2 ** 256 - 1)
     )
 
     # Assert: balance
     assert membership_token.call().balanceOf(issuer) == 0
-    assert membership_token.call().balanceOf(trader) == 2**256 - 1
-    assert membership_exchange.call().\
-        balances(issuer, membership_token.address) == 0
+    assert membership_token.call().balanceOf(trader) == 2 ** 256 - 1
+    assert membership_exchange.call().balanceOf(issuer, membership_token.address) == 0
+
 
 # エラー系１
 #   入力値の型誤り（token）
-def test_transfer_error_1(web3, chain, users, membership_exchange):
+def test_transfer_error_1(web3, users, membership_exchange):
     issuer = users['issuer']
     trader = users['trader']
 
@@ -3623,11 +3638,11 @@ def test_transfer_error_1(web3, chain, users, membership_exchange):
     with pytest.raises(TypeError):
         membership_exchange.transact().transfer('1234', trader, 100)
 
+
 # エラー系2
 #   入力値の型誤り（to）
 def test_transfer_error_2(web3, chain, users, membership_exchange):
     issuer = users['issuer']
-    trader = users['trader']
 
     # 新規発行
     web3.eth.defaultAccount = issuer
@@ -3638,12 +3653,13 @@ def test_transfer_error_2(web3, chain, users, membership_exchange):
     web3.eth.defaultAccount = issuer
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().\
+        membership_exchange.transact(). \
             transfer(membership_token.address, 1234, 100)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().\
+        membership_exchange.transact(). \
             transfer(membership_token.address, '1234', 100)
+
 
 # エラー系3
 #   入力値の型誤り（_value）
@@ -3660,20 +3676,17 @@ def test_transfer_error_3(web3, chain, users, membership_exchange):
     web3.eth.defaultAccount = issuer
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().\
-            transfer(membership_token.address, trader, -1)
+        membership_exchange.transact().transfer(membership_token.address, trader, -1)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().\
-            transfer(membership_token.address, trader, 2**256)
+        membership_exchange.transact().transfer(membership_token.address, trader, 2 ** 256)
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().\
-            transfer(membership_token.address, trader, '0')
+        membership_exchange.transact().transfer(membership_token.address, trader, '0')
 
     with pytest.raises(TypeError):
-        membership_exchange.transact().\
-            transfer(membership_token.address, trader, 0.1)
+        membership_exchange.transact().transfer(membership_token.address, trader, 0.1)
+
 
 # エラー系4
 #   送信数量が0の場合
@@ -3696,15 +3709,14 @@ def test_transfer_error_4(web3, chain, users, membership_exchange):
     # 送信：エラー
     web3.eth.defaultAccount = issuer
     chain.wait.for_receipt(
-        membership_exchange.transact().\
-            transfer(membership_token.address, trader, 0)
-    ) # エラーになる
+        membership_exchange.transact().transfer(membership_token.address, trader, 0)
+    )  # エラーになる
 
     # Assert: balance
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
     assert membership_token.call().balanceOf(trader) == 0
-    assert membership_exchange.call().\
-        balances(issuer, membership_token.address) == 0
+    assert membership_exchange.call().balanceOf(issuer, membership_token.address) == 0
+
 
 # エラー系5
 #   残高数量が送信数量に満たない場合
@@ -3727,12 +3739,72 @@ def test_transfer_error_5(web3, chain, users, membership_exchange):
     # 送信：エラー
     web3.eth.defaultAccount = issuer
     chain.wait.for_receipt(
-        membership_exchange.transact().\
-            transfer(membership_token.address, trader, 101)
-    ) # エラーになる
+        membership_exchange.transact().transfer(membership_token.address, trader, 101)
+    )  # エラーになる
 
     # Assert: balance
     assert membership_token.call().balanceOf(issuer) == deploy_args[2]
     assert membership_token.call().balanceOf(trader) == 0
-    assert membership_exchange.call().\
-        balances(issuer, membership_token.address) == 0
+    assert membership_exchange.call().balanceOf(issuer, membership_token.address) == 0
+
+
+'''
+TEST9_Exchange切替
+'''
+
+
+# 正常系
+def test_updateExchange_normal_1(web3, chain, users, membership_exchange,
+                                 membership_exchange_storage, payment_gateway):
+    issuer = users['issuer']
+    agent = users['agent']
+    admin = users['admin']
+
+    # 新規発行
+    web3.eth.defaultAccount = issuer
+    deploy_args = init_args(membership_exchange.address)
+    membership_token = deploy(chain, deploy_args)
+
+    # Exchangeへのデポジット
+    deposit(
+        web3, chain,
+        membership_token, membership_exchange,
+        issuer, 100
+    )
+
+    # Make注文（売）
+    _price = 123
+    _isBuy = False
+    make_order(
+        web3, chain,
+        membership_token, membership_exchange,
+        issuer, 10, _price, _isBuy, agent
+    )
+
+    # Exchange（新）
+    web3.eth.defaultAccount = admin
+    membership_exchange_new, _ = chain.provider.get_or_deploy_contract(
+        'IbetMembershipExchange',
+        deploy_args=[payment_gateway.address, membership_exchange_storage.address]
+    )
+    txn_hash = membership_exchange_storage.transact().\
+        upgradeVersion(membership_exchange_new.address)
+    chain.wait.for_receipt(txn_hash)
+
+    # Exchange（新）からの情報参照
+    web3.eth.defaultAccount = issuer
+    order_id = membership_exchange_new.call().latestOrderId()
+    orderbook = membership_exchange_new.call().getOrder(order_id)
+    issuer_commitment = membership_exchange_new.call(). \
+        commitmentOf(issuer, membership_token.address)
+    issuer_balance_exchange = membership_exchange_new.call(). \
+        balanceOf(issuer, membership_token.address)
+    issuer_balance_token = membership_token.call().balanceOf(issuer)
+
+    assert orderbook == [
+        issuer, to_checksum_address(membership_token.address),
+        10, _price, _isBuy, agent, False
+    ]
+    assert issuer_balance_token == deploy_args[2] - 100
+    assert issuer_balance_exchange == 90
+    assert issuer_commitment == 10

--- a/tests/test_ibetstraightbond.py
+++ b/tests/test_ibetstraightbond.py
@@ -2,6 +2,7 @@ import pytest
 import utils
 from eth_utils import to_checksum_address
 
+
 def init_args(exchange_address):
     name = 'test_bond'
     symbol = 'BND'
@@ -25,9 +26,12 @@ def init_args(exchange_address):
     ]
     return deploy_args
 
+
 '''
 TEST1_デプロイ
 '''
+
+
 # 正常系1: deploy
 def test_deploy_normal_1(web3, chain, users, bond_exchange):
     account_address = users['issuer']
@@ -36,7 +40,7 @@ def test_deploy_normal_1(web3, chain, users, bond_exchange):
     web3.eth.defaultAccount = account_address
     bond_contract, _ = chain.provider.get_or_deploy_contract(
         'IbetStraightBond',
-        deploy_args = deploy_args
+        deploy_args=deploy_args
     )
 
     owner_address = bond_contract.call().owner()
@@ -69,100 +73,116 @@ def test_deploy_normal_1(web3, chain, users, bond_exchange):
     assert purpose == deploy_args[11]
     assert memo == deploy_args[12]
 
+
 # エラー系1: 入力値の型誤り（name）
 def test_deploy_error_1(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[0] = 1234
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 # エラー系2: 入力値の型誤り（symbol）
 def test_deploy_error_2(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[1] = 1234
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 # エラー系3: 入力値の型誤り（totalSupply）
 def test_deploy_error_3(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[2] = "10000"
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 # エラー系4: 入力値の型誤り（faceValue）
 def test_deploy_error_4(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[4] = "10000"
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 # エラー系5: 入力値の型誤り（interestRate）
 def test_deploy_error_5(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[5] = "1000"
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 # エラー系6: 入力値の型誤り（interestPaymentDate）
 def test_deploy_error_6(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[6] = 1231
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 # エラー系7: 入力値の型誤り（redemptionDate）
 def test_deploy_error_7(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[7] = 20191231
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 # エラー系8: 入力値の型誤り（redemptionAmount）
 def test_deploy_error_8(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[8] = "100"
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 # エラー系9: 入力値の型誤り（returnDate）
 def test_deploy_error_9(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[9] = 20191231
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 # エラー系10: 入力値の型誤り（returnAmount）
 def test_deploy_error_10(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[10] = 1234
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 # エラー系11: 入力値の型誤り（purpose）
 def test_deploy_error_11(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[11] = 1234
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 # エラー系12: 入力値の型誤り（memo）
 def test_deploy_error_12(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[12] = 1234
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 # エラー系13: 入力値の型誤り（tradableExchange）
 def test_deploy_error_13(chain, bond_exchange):
     deploy_args = init_args(bond_exchange.address)
     deploy_args[3] = '0xaaaa'
     with pytest.raises(TypeError):
-        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args = deploy_args)
+        chain.provider.get_or_deploy_contract('IbetStraightBond', deploy_args=deploy_args)
+
 
 '''
 TEST2_トークンの振替（transfer）
 '''
+
+
 # 正常系1: アカウントアドレスへの振替
 def test_transfer_normal_1(web3, chain, users, bond_exchange):
     from_address = users['issuer']
@@ -171,7 +191,7 @@ def test_transfer_normal_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = from_address
-    bond_contract, deploy_args = utils.\
+    bond_contract, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     txn_hash = bond_contract.transact().transfer(to_address, transfer_amount)
@@ -183,14 +203,15 @@ def test_transfer_normal_1(web3, chain, users, bond_exchange):
     assert from_balance == deploy_args[2] - transfer_amount
     assert to_balance == transfer_amount
 
+
 # 正常系2: 債券取引コントラクトへの振替
-def test_transfer_normal_2(web3,chain, users, bond_exchange):
+def test_transfer_normal_2(web3, chain, users, bond_exchange):
     from_address = users['issuer']
     transfer_amount = 100
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = from_address
-    bond_contract, deploy_args = utils.\
+    bond_contract, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     to_address = bond_exchange.address
@@ -203,6 +224,7 @@ def test_transfer_normal_2(web3,chain, users, bond_exchange):
     assert from_balance == deploy_args[2] - transfer_amount
     assert to_balance == transfer_amount
 
+
 # エラー系1: 入力値の型誤り（To）
 def test_transfer_error_1(web3, chain, users, bond_exchange):
     from_address = users['issuer']
@@ -211,11 +233,12 @@ def test_transfer_error_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = from_address
-    bond_contract, deploy_args = utils.\
+    bond_contract, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     with pytest.raises(TypeError):
         bond_contract.transact().transfer(to_address, transfer_amount)
+
 
 # エラー系2: 入力値の型誤り（Value）
 def test_transfer_error_2(web3, chain, users, bond_exchange):
@@ -225,11 +248,12 @@ def test_transfer_error_2(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = from_address
-    bond_contract, deploy_args = utils.\
+    bond_contract, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     with pytest.raises(TypeError):
         bond_contract.transact().transfer(to_address, transfer_amount)
+
 
 # エラー系3: 残高不足
 def test_transfer_error_3(web3, chain, users, bond_exchange):
@@ -239,7 +263,7 @@ def test_transfer_error_3(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = from_address
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 債券トークン振替（残高超）
@@ -249,6 +273,7 @@ def test_transfer_error_3(web3, chain, users, bond_exchange):
 
     assert bond_token.call().balanceOf(issuer) == 10000
     assert bond_token.call().balanceOf(to_address) == 0
+
 
 # エラー系4: private functionにアクセスできない
 def test_transfer_error_4(web3, chain, users, bond_exchange):
@@ -261,7 +286,7 @@ def test_transfer_error_4(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = from_address
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     with pytest.raises(ValueError):
@@ -273,25 +298,30 @@ def test_transfer_error_4(web3, chain, users, bond_exchange):
     with pytest.raises(ValueError):
         bond_token.transact().transferToContract(to_address, transfer_amount, data)
 
+
 # エラー系5: 取引不可Exchangeへの振替
-def test_transfer_error_5(web3,chain, users, bond_exchange, payment_gateway):
+def test_transfer_error_5(web3, chain, users, bond_exchange,
+                          coupon_exchange_storage, payment_gateway):
     from_address = users['issuer']
     transfer_amount = 100
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = from_address
-    bond_contract, deploy_args = utils.\
+    bond_contract, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 取引不可Exchange
     web3.eth.defaultAccount = users['admin']
     dummy_exchange, _ = chain.provider.get_or_deploy_contract(
-        'IbetCouponExchange', # IbetStraightBondExchange以外を読み込む必要がある
-        deploy_args = [payment_gateway.address]
+        'IbetCouponExchange',  # IbetStraightBondExchange以外を読み込む必要がある
+        deploy_args=[
+            payment_gateway.address,
+            coupon_exchange_storage.address
+        ]
     )
 
     to_address = dummy_exchange.address
-    txn_hash = bond_contract.transact().transfer(to_address, transfer_amount) #エラーになる
+    txn_hash = bond_contract.transact().transfer(to_address, transfer_amount)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     from_balance = bond_contract.call().balanceOf(from_address)
@@ -300,20 +330,24 @@ def test_transfer_error_5(web3,chain, users, bond_exchange, payment_gateway):
     assert from_balance == deploy_args[2]
     assert to_balance == 0
 
+
 '''
 TEST3_残高確認（balanceOf）
 '''
+
+
 # 正常系1: 商品コントラクト作成 -> 残高確認
 def test_balanceOf_normal_1(web3, chain, users, bond_exchange):
     issuer = users['issuer']
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     balance = bond_token.call().balanceOf(issuer)
     assert balance == 10000
+
 
 # エラー系1: 入力値の型誤り（Owner）
 def test_balanceOf_error_1(web3, chain, users, bond_exchange):
@@ -321,7 +355,7 @@ def test_balanceOf_error_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     account_address = 1234
@@ -329,9 +363,12 @@ def test_balanceOf_error_1(web3, chain, users, bond_exchange):
     with pytest.raises(TypeError):
         bond_token.call().balanceOf(account_address)
 
+
 '''
 TEST4_認定リクエスト（requestSignature）
 '''
+
+
 # 正常系1: 初期値が0
 def test_requestSignature_normal_1(web3, chain, users, bond_exchange):
     issuer = users['issuer']
@@ -339,11 +376,12 @@ def test_requestSignature_normal_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     signature = bond_token.call().signatures(signer)
     assert signature == 0
+
 
 # 正常系2: 認定リクエスト
 def test_requestSignature_normal_2(web3, chain, users, bond_exchange):
@@ -352,7 +390,7 @@ def test_requestSignature_normal_2(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     txn_hash = bond_token.transact().requestSignature(signer)
@@ -361,6 +399,7 @@ def test_requestSignature_normal_2(web3, chain, users, bond_exchange):
     signature = bond_token.call().signatures(signer)
     assert signature == 1
 
+
 # エラー系1: 入力値の型誤り（Signer）
 def test_requestSignature_error_1(web3, chain, users, bond_exchange):
     issuer = users['issuer']
@@ -368,15 +407,18 @@ def test_requestSignature_error_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     with pytest.raises(TypeError):
         bond_token.transact().requestSignature(signer)
 
+
 '''
 TEST5_認定（sign）
 '''
+
+
 # 正常系1: 認定リクエスト -> 認定
 def test_sign_normal_1(web3, chain, users, bond_exchange):
     issuer = users['issuer']
@@ -384,7 +426,7 @@ def test_sign_normal_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 認定リクエスト -> Success
@@ -400,6 +442,7 @@ def test_sign_normal_1(web3, chain, users, bond_exchange):
     signature = bond_token.call().signatures(signer)
     assert signature == 2
 
+
 # エラー系1: 認定リクエスト未実施 -> 認定
 def test_sign_error_1(web3, chain, users, bond_exchange):
     issuer = users['issuer']
@@ -407,15 +450,16 @@ def test_sign_error_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 認定 -> Failure
     web3.eth.defaultAccount = signer
-    txn_hash = bond_token.transact().sign()
+    bond_token.transact().sign()
 
     signature = bond_token.call().signatures(signer)
     assert signature == 0
+
 
 # エラー系2: 認定リクエスト-> 異なるSinerから認定をした場合
 def test_sign_error_2(web3, chain, users, bond_exchange):
@@ -425,7 +469,7 @@ def test_sign_error_2(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 認定リクエスト -> Success
@@ -441,9 +485,12 @@ def test_sign_error_2(web3, chain, users, bond_exchange):
     signature = bond_token.call().signatures(signer)
     assert signature == 1
 
+
 '''
 TEST6_認定取消（unsign）
 '''
+
+
 # 正常系1: 認定リクエスト -> 認定 -> 認定取消
 def test_unsign_normal_1(web3, chain, users, bond_exchange):
     issuer = users['issuer']
@@ -451,7 +498,7 @@ def test_unsign_normal_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 認定リクエスト -> Success
@@ -472,6 +519,7 @@ def test_unsign_normal_1(web3, chain, users, bond_exchange):
     signature = bond_token.call().signatures(signer)
     assert signature == 0
 
+
 # エラー系1: 認定リクエスト未実施 -> 認定取消
 def test_unsign_error_1(web3, chain, users, bond_exchange):
     issuer = users['issuer']
@@ -479,7 +527,7 @@ def test_unsign_error_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 認定取消 -> Failure
@@ -490,6 +538,7 @@ def test_unsign_error_1(web3, chain, users, bond_exchange):
     signature = bond_token.call().signatures(signer)
     assert signature == 0
 
+
 # エラー系2: 認定リクエスト -> （認定未実施） -> 認定取消
 def test_unsign_error_2(web3, chain, users, bond_exchange):
     issuer = users['issuer']
@@ -497,7 +546,7 @@ def test_unsign_error_2(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 認定リクエスト -> Success
@@ -513,6 +562,7 @@ def test_unsign_error_2(web3, chain, users, bond_exchange):
     signature = bond_token.call().signatures(signer)
     assert signature == 1
 
+
 # エラー系3: 認定リクエスト-> 認定 -> 異なるSinerから認定取消を実施した場合
 def test_unsign_error_3(web3, chain, users, bond_exchange):
     issuer = users['issuer']
@@ -521,7 +571,7 @@ def test_unsign_error_3(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 認定リクエスト -> Success
@@ -542,17 +592,19 @@ def test_unsign_error_3(web3, chain, users, bond_exchange):
     signature = bond_token.call().signatures(signer)
     assert signature == 2
 
+
 '''
 TEST7_償還（redeem）
 '''
+
+
 # 正常系1: 発行（デプロイ） -> 償還
 def test_redeem_normal_1(web3, chain, users, bond_exchange):
     issuer = users['issuer']
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
-        issue_bond_token(web3, chain, users, bond_exchange.address)
+    bond_token, deploy_args = utils.issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 償還 -> Success
     web3.eth.defaultAccount = issuer
@@ -560,7 +612,8 @@ def test_redeem_normal_1(web3, chain, users, bond_exchange):
     chain.wait.for_receipt(txn_hash)
 
     is_redeemed = bond_token.call().isRedeemed()
-    assert is_redeemed == True
+    assert is_redeemed is True
+
 
 # エラー系1: issuer以外のアドレスから償還を実施した場合
 def test_redeem_error_1(web3, chain, users, bond_exchange):
@@ -569,8 +622,7 @@ def test_redeem_error_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
-        issue_bond_token(web3, chain, users, bond_exchange.address)
+    bond_token, deploy_args = utils.issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # Owner以外のアドレスから償還を実施 -> Failure
     web3.eth.defaultAccount = other
@@ -578,18 +630,21 @@ def test_redeem_error_1(web3, chain, users, bond_exchange):
     chain.wait.for_receipt(txn_hash)
 
     is_redeemed = bond_token.call().isRedeemed()
-    assert is_redeemed == False
+    assert is_redeemed is False
+
 
 '''
 TEST8_商品画像の設定（setImageURL, getImageURL）
 '''
+
+
 # 正常系1: 発行（デプロイ） -> 商品画像の設定
 def test_setImageURL_normal_1(web3, chain, users, bond_exchange):
     issuer = users['issuer']
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     image_url = 'https://some_image_url.com/image.png'
@@ -602,13 +657,14 @@ def test_setImageURL_normal_1(web3, chain, users, bond_exchange):
     image_url_0 = bond_token.call().getImageURL(0)
     assert image_url_0 == image_url
 
+
 # 正常系2: 発行（デプロイ） -> 商品画像の設定（複数設定）
 def test_setImageURL_normal_2(web3, chain, users, bond_exchange):
     issuer = users['issuer']
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     image_url = 'https://some_image_url.com/image.png'
@@ -628,13 +684,14 @@ def test_setImageURL_normal_2(web3, chain, users, bond_exchange):
     assert image_url_0 == image_url
     assert image_url_1 == image_url
 
+
 # 正常系3: 発行（デプロイ） -> 商品画像の設定（上書き登録）
 def test_setImageURL_normal_3(web3, chain, users, bond_exchange):
     issuer = users['issuer']
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     image_url = 'https://some_image_url.com/image.png'
@@ -653,13 +710,14 @@ def test_setImageURL_normal_3(web3, chain, users, bond_exchange):
     image_url_0 = bond_token.call().getImageURL(0)
     assert image_url_0 == image_url_after
 
+
 # エラー系1: 入力値の型誤り（Class）
 def test_setImageURL_error_1(web3, chain, users, bond_exchange):
     issuer = users['issuer']
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     image_url = 'https://some_image_url.com/image.png'
@@ -675,13 +733,14 @@ def test_setImageURL_error_1(web3, chain, users, bond_exchange):
     with pytest.raises(TypeError):
         bond_token.transact().setImageURL('0', image_url)
 
+
 # エラー系2: 入力値の型誤り（ImageURL）
 def test_setImageURL_error_2(web3, chain, users, bond_exchange):
     issuer = users['issuer']
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     image_url = 1234
@@ -690,6 +749,7 @@ def test_setImageURL_error_2(web3, chain, users, bond_exchange):
     with pytest.raises(TypeError):
         bond_token.transact().setImageURL(0, image_url)
 
+
 # エラー系3: Issuer以外のアドレスから画像設定を実施した場合
 def test_setImageURL_error_3(web3, chain, users, bond_exchange):
     issuer = users['issuer']
@@ -697,7 +757,7 @@ def test_setImageURL_error_3(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     image_url = 'https://some_image_url.com/image.png'
@@ -710,16 +770,19 @@ def test_setImageURL_error_3(web3, chain, users, bond_exchange):
     image_url_0 = bond_token.call().getImageURL(0)
     assert image_url_0 == ''
 
+
 '''
 TEST9_メモの更新（updateMemo）
 '''
+
+
 # 正常系1: 発行（デプロイ） -> メモ欄の修正
 def test_updateMemo_normal_1(web3, chain, users, bond_exchange):
     issuer = users['issuer']
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # メモ欄の修正 -> Success
@@ -730,18 +793,20 @@ def test_updateMemo_normal_1(web3, chain, users, bond_exchange):
     memo = bond_token.call().memo()
     assert memo == 'updated memo'
 
+
 # エラー系1: 入力値の型誤り
 def test_updateMemo_error_1(web3, chain, users, bond_exchange):
     issuer = users['issuer']
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     web3.eth.defaultAccount = issuer
     with pytest.raises(TypeError):
         bond_token.transact().updateMemo(1234)
+
 
 # エラー系2: Owner以外のアドレスからメモ欄の修正を実施した場合
 def test_updateMemo_error_2(web3, chain, users, bond_exchange):
@@ -750,19 +815,22 @@ def test_updateMemo_error_2(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # Owner以外のアドレスからメモ欄の修正を実施 -> Failure
     web3.eth.defaultAccount = other
-    txn_hash = bond_token.transact().updateMemo('updated memo')
+    bond_token.transact().updateMemo('updated memo')
 
     memo = bond_token.call().memo()
     assert memo == 'some_memo'
 
+
 '''
 TEST10_トークンの移転（transferFrom）
 '''
+
+
 # 正常系1: アカウントアドレスへの移転
 def test_transferFrom_normal_1(web3, chain, users, bond_exchange):
     _issuer = users['issuer']
@@ -772,7 +840,7 @@ def test_transferFrom_normal_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = _issuer
-    bond_contract, deploy_args = utils.\
+    bond_contract, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 譲渡（issuer -> _from）
@@ -793,6 +861,7 @@ def test_transferFrom_normal_1(web3, chain, users, bond_exchange):
     assert from_balance == 0
     assert to_balance == _value
 
+
 # エラー系1: 入力値の型誤り（From）
 def test_transferFrom_error_1(web3, chain, users, bond_exchange):
     _issuer = users['issuer']
@@ -801,7 +870,7 @@ def test_transferFrom_error_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = _issuer
-    bond_contract, deploy_args = utils.\
+    bond_contract, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 移転（_from -> _to）
@@ -813,6 +882,7 @@ def test_transferFrom_error_1(web3, chain, users, bond_exchange):
     with pytest.raises(TypeError):
         bond_contract.transact().transferFrom(1234, _to, _value)
 
+
 # エラー系2: 入力値の型誤り（To）
 def test_transferFrom_error_2(web3, chain, users, bond_exchange):
     _issuer = users['issuer']
@@ -821,7 +891,7 @@ def test_transferFrom_error_2(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = _issuer
-    bond_contract, deploy_args = utils.\
+    bond_contract, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 移転（_from -> _to）
@@ -833,6 +903,7 @@ def test_transferFrom_error_2(web3, chain, users, bond_exchange):
     with pytest.raises(TypeError):
         bond_contract.transact().transferFrom(_from, 1234, _value)
 
+
 # エラー系3: 入力値の型誤り（Value）
 def test_transferFrom_error_3(web3, chain, users, bond_exchange):
     _issuer = users['issuer']
@@ -841,7 +912,7 @@ def test_transferFrom_error_3(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = _issuer
-    bond_contract, deploy_args = utils.\
+    bond_contract, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 移転（_from -> _to）
@@ -851,13 +922,14 @@ def test_transferFrom_error_3(web3, chain, users, bond_exchange):
         bond_contract.transact().transferFrom(_from, _to, -1)
 
     with pytest.raises(TypeError):
-        bond_contract.transact().transferFrom(_from, _to, 2**256)
+        bond_contract.transact().transferFrom(_from, _to, 2 ** 256)
 
     with pytest.raises(TypeError):
         bond_contract.transact().transferFrom(_from, _to, '0')
 
     with pytest.raises(TypeError):
         bond_contract.transact().transferFrom(_from, _to, 0.1)
+
 
 # エラー系4: 残高不足
 def test_transferFrom_error_4(web3, chain, users, bond_exchange):
@@ -868,7 +940,7 @@ def test_transferFrom_error_4(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = _issuer
-    bond_contract, deploy_args = utils.\
+    bond_contract, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 譲渡（issuer -> _from）
@@ -878,7 +950,7 @@ def test_transferFrom_error_4(web3, chain, users, bond_exchange):
 
     # 移転（_from -> _to）
     web3.eth.defaultAccount = _issuer
-    txn_hash = bond_contract.transact().transferFrom(_from, _to, 101) # エラーになる
+    txn_hash = bond_contract.transact().transferFrom(_from, _to, 101)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     issuer_balance = bond_contract.call().balanceOf(_issuer)
@@ -888,6 +960,7 @@ def test_transferFrom_error_4(web3, chain, users, bond_exchange):
     assert issuer_balance == deploy_args[2] - _value
     assert from_balance == _value
     assert to_balance == 0
+
 
 # エラー系5: 権限エラー
 def test_transferFrom_error_5(web3, chain, users, bond_exchange):
@@ -898,7 +971,7 @@ def test_transferFrom_error_5(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = _issuer
-    bond_contract, deploy_args = utils.\
+    bond_contract, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # 譲渡（issuer -> _from）
@@ -908,7 +981,7 @@ def test_transferFrom_error_5(web3, chain, users, bond_exchange):
 
     # 移転（_from -> _to）
     web3.eth.defaultAccount = _from
-    txn_hash = bond_contract.transact().transferFrom(_from, _to, _value) # エラーになる
+    txn_hash = bond_contract.transact().transferFrom(_from, _to, _value)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
     issuer_balance = bond_contract.call().balanceOf(_issuer)
@@ -919,23 +992,30 @@ def test_transferFrom_error_5(web3, chain, users, bond_exchange):
     assert from_balance == _value
     assert to_balance == 0
 
+
 '''
 TEST11_取引可能Exchangeの更新（setTradableExchange）
 '''
+
+
 # 正常系1: 発行 -> Exchangeの更新
-def test_setTradableExchange_normal_1(web3, chain, users, bond_exchange, payment_gateway):
+def test_setTradableExchange_normal_1(web3, chain, users, bond_exchange,
+                                      coupon_exchange_storage, payment_gateway):
     issuer = users['issuer']
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # その他Exchange
     web3.eth.defaultAccount = users['admin']
     other_exchange, _ = chain.provider.get_or_deploy_contract(
-        'IbetCouponExchange', # IbetStraightBondExchange以外を読み込む必要がある
-        deploy_args = [payment_gateway.address]
+        'IbetCouponExchange',  # IbetStraightBondExchange以外を読み込む必要がある
+        deploy_args=[
+            payment_gateway.address,
+            coupon_exchange_storage.address
+        ]
     )
 
     # Exchangeの更新
@@ -943,8 +1023,8 @@ def test_setTradableExchange_normal_1(web3, chain, users, bond_exchange, payment
     txn_hash = bond_token.transact().setTradableExchange(other_exchange.address)
     chain.wait.for_receipt(txn_hash)
 
-    assert bond_token.call().tradableExchange() == \
-        to_checksum_address(other_exchange.address)
+    assert bond_token.call().tradableExchange() == to_checksum_address(other_exchange.address)
+
 
 # エラー系1: 発行 -> Exchangeの更新（入力値の型誤り）
 def test_setTradableExchange_error_1(web3, chain, users, bond_exchange):
@@ -952,7 +1032,7 @@ def test_setTradableExchange_error_1(web3, chain, users, bond_exchange):
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # Exchangeの更新
@@ -960,28 +1040,32 @@ def test_setTradableExchange_error_1(web3, chain, users, bond_exchange):
     with pytest.raises(TypeError):
         bond_token.transact().setTradableExchange('0xaaaa')
 
+
 # エラー系2: 発行 -> Exchangeの更新（権限エラー）
-def test_setTradableExchange_error_2(web3, chain, users, bond_exchange, payment_gateway):
+def test_setTradableExchange_error_2(web3, chain, users, bond_exchange,
+                                     coupon_exchange_storage, payment_gateway):
     issuer = users['issuer']
     trader = users['trader']
 
     # 債券トークン新規発行
     web3.eth.defaultAccount = issuer
-    bond_token, deploy_args = utils.\
+    bond_token, deploy_args = utils. \
         issue_bond_token(web3, chain, users, bond_exchange.address)
 
     # その他Exchange
     web3.eth.defaultAccount = users['admin']
     other_exchange, _ = chain.provider.get_or_deploy_contract(
-        'IbetCouponExchange', # IbetStraightBondExchange以外を読み込む必要がある
-        deploy_args = [payment_gateway.address]
+        'IbetCouponExchange',  # IbetStraightBondExchange以外を読み込む必要がある
+        deploy_args=[
+            payment_gateway.address,
+            coupon_exchange_storage.address
+        ]
     )
 
     # Exchangeの更新
     web3.eth.defaultAccount = trader
-    txn_hash = bond_token.transact().\
-        setTradableExchange(other_exchange.address) #エラーになる
+    txn_hash = bond_token.transact(). \
+        setTradableExchange(other_exchange.address)  # エラーになる
     chain.wait.for_receipt(txn_hash)
 
-    assert bond_token.call().tradableExchange() == \
-        to_checksum_address(bond_exchange.address)
+    assert bond_token.call().tradableExchange() == to_checksum_address(bond_exchange.address)

--- a/tests/test_paymentgateway.py
+++ b/tests/test_paymentgateway.py
@@ -8,6 +8,8 @@ terms_text_after = 'terms_sample\nafter\nend'
 '''
 TEST0_デプロイ
 '''
+
+
 # 正常系1: デプロイ
 def test_deploy_normal_1(web3, chain, users):
     admin = users['admin']
@@ -33,20 +35,23 @@ def test_deploy_normal_1(web3, chain, users):
     # デフォルトの規約同意情報の内容が正しいことを確認
     assert agreement[0] == '0x0000000000000000000000000000000000000000'
     assert agreement[1] == '0x0000000000000000000000000000000000000000'
-    assert agreement[2] == False
+    assert agreement[2] is False
 
     # 認可状態が未認可の状態であることを確認
-    assert account_approved == False
+    assert account_approved is False
 
     # 利用規約同意状態が未同意であることを確認
-    assert term_agreement_status == False
+    assert term_agreement_status is False
 
     # 最新の版番がゼロであることを確認
     assert latest_terms_version == 0
 
+
 '''
 TEST1_支払情報を登録（register）
 '''
+
+
 # 正常系1: 新規登録
 def test_register_normal_1(web3, chain, users):
     admin = users['admin']
@@ -64,7 +69,7 @@ def test_register_normal_1(web3, chain, users):
 
     # PaymentGateway登録
     web3.eth.defaultAccount = trader
-    txn_hash = pg_contract.transact().register(agent,encrypted_message)
+    txn_hash = pg_contract.transact().register(agent, encrypted_message)
     chain.wait.for_receipt(txn_hash)
 
     latest_terms_version = pg_contract.call().latest_terms_version(agent)
@@ -83,16 +88,17 @@ def test_register_normal_1(web3, chain, users):
     # 規約同意情報の内容が正しいことを確認
     assert agreement[0] == trader
     assert agreement[1] == agent
-    assert agreement[2] == True
+    assert agreement[2] is True
 
     # 認可状態が未認可の状態であることを確認
-    assert account_approved == False
+    assert account_approved is False
 
     # 利用規約同意状態（最新版）が同意済であることを確認
-    assert term_agreement_status == True
+    assert term_agreement_status is True
 
     # 最新の版番の確認
     assert latest_terms_version == 1
+
 
 # 正常系2: 新規登録 -> 更新
 def test_register_normal_2(web3, chain, users):
@@ -111,12 +117,12 @@ def test_register_normal_2(web3, chain, users):
 
     # 登録 -> Success
     web3.eth.defaultAccount = trader
-    txn_hash_1 = pg_contract.transact().register(agent,encrypted_message)
+    txn_hash_1 = pg_contract.transact().register(agent, encrypted_message)
     chain.wait.for_receipt(txn_hash_1)
 
     # 登録（２回目） -> Success
     web3.eth.defaultAccount = trader
-    txn_hash_2 = pg_contract.transact().register(agent,encrypted_message_after)
+    txn_hash_2 = pg_contract.transact().register(agent, encrypted_message_after)
     chain.wait.for_receipt(txn_hash_2)
 
     latest_terms_version = pg_contract.call().latest_terms_version(agent)
@@ -135,16 +141,17 @@ def test_register_normal_2(web3, chain, users):
     # 規約同意情報の内容が正しいことを確認
     assert agreement[0] == trader
     assert agreement[1] == agent
-    assert agreement[2] == True
+    assert agreement[2] is True
 
     # 認可状態が未認可の状態であることを確認
-    assert account_approved == False
+    assert account_approved is False
 
     # 利用規約同意状態（最新版）が同意済であることを確認
-    assert term_agreement_status == True
+    assert term_agreement_status is True
 
     # 最新の版番の確認
     assert latest_terms_version == 1
+
 
 # エラー系1:入力値の型誤り（agent address）
 def test_register_error_1(web3, chain, users):
@@ -159,7 +166,8 @@ def test_register_error_1(web3, chain, users):
     # PaymentGateway登録 -> Failure
     web3.eth.defaultAccount = trader
     with pytest.raises(TypeError):
-        pg_contract.transact().register(agent,encrypted_message)
+        pg_contract.transact().register(agent, encrypted_message)
+
 
 # エラー系2:入力値の型誤り（encrypted_info）
 def test_register_error_2(web3, chain, users):
@@ -173,9 +181,9 @@ def test_register_error_2(web3, chain, users):
 
     # PaymentGateway登録 -> Failure
     web3.eth.defaultAccount = trader
-    encrypted_message = 1234
     with pytest.raises(TypeError):
-        pg_contract.transact().register(agent,encrypted_message)
+        pg_contract.transact().register(agent, 1234)
+
 
 # エラー系3: 登録 -> BAN -> 登録（２回目）
 def test_register_error_3(web3, chain, users):
@@ -194,7 +202,7 @@ def test_register_error_3(web3, chain, users):
 
     # 新規登録 -> Success
     web3.eth.defaultAccount = trader
-    txn_hash_1 = pg_contract.transact().register(agent,encrypted_message)
+    txn_hash_1 = pg_contract.transact().register(agent, encrypted_message)
     chain.wait.for_receipt(txn_hash_1)
 
     # BAN -> Success
@@ -204,7 +212,7 @@ def test_register_error_3(web3, chain, users):
 
     # 登録（２回目） -> Failure
     web3.eth.defaultAccount = trader
-    txn_hash_3 = pg_contract.transact().register(agent,encrypted_message_after)
+    txn_hash_3 = pg_contract.transact().register(agent, encrypted_message_after)
     chain.wait.for_receipt(txn_hash_3)
 
     payment_account = pg_contract.call().payment_accounts(trader, agent)
@@ -217,7 +225,8 @@ def test_register_error_3(web3, chain, users):
     assert payment_account[3] == 4
 
     # 認可状態が未認可の状態であることを確認
-    assert account_approved == False
+    assert account_approved is False
+
 
 # エラー系4: 利用規約未登録 -> 口座登録
 def test_register_error_4(web3, chain, users):
@@ -231,7 +240,7 @@ def test_register_error_4(web3, chain, users):
 
     # 新規登録 -> Failure
     web3.eth.defaultAccount = trader
-    txn_hash_1 = pg_contract.transact().register(agent,encrypted_message)
+    txn_hash_1 = pg_contract.transact().register(agent, encrypted_message)
     chain.wait.for_receipt(txn_hash_1)
 
     payment_account = pg_contract.call().payment_accounts(trader, agent)
@@ -244,11 +253,14 @@ def test_register_error_4(web3, chain, users):
     assert payment_account[3] == 0
 
     # 認可状態が未認可の状態であることを確認
-    assert account_approved == False
+    assert account_approved is False
+
 
 '''
 TEST2_支払情報を承認する(approve)
 '''
+
+
 # 正常系1: 新規登録 -> 承認
 def test_approve_normal_1(web3, chain, users):
     admin = users['admin']
@@ -266,7 +278,7 @@ def test_approve_normal_1(web3, chain, users):
 
     # 新規登録 -> Success
     web3.eth.defaultAccount = trader
-    txn_hash_1 = pg_contract.transact().register(agent,encrypted_message)
+    txn_hash_1 = pg_contract.transact().register(agent, encrypted_message)
     chain.wait.for_receipt(txn_hash_1)
 
     # 承認 -> Success
@@ -284,7 +296,8 @@ def test_approve_normal_1(web3, chain, users):
     assert payment_account[3] == 2
 
     # 認可状態が認可の状態であることを確認
-    assert account_approved == True
+    assert account_approved is True
+
 
 # エラー系1: 入力値の型誤り
 def test_approve_error_1(web3, chain, users):
@@ -301,6 +314,7 @@ def test_approve_error_1(web3, chain, users):
     with pytest.raises(TypeError):
         pg_contract.transact().approve(trader)
 
+
 # エラー系2: 登録なし -> 承認
 def test_approve_error_2(web3, chain, users):
     admin = users['admin']
@@ -313,15 +327,18 @@ def test_approve_error_2(web3, chain, users):
 
     # 承認 -> Failure
     web3.eth.defaultAccount = agent
-    txn_hash = pg_contract.transact().approve(trader)
+    pg_contract.transact().approve(trader)
 
     payment_account = pg_contract.call().payment_accounts(trader, agent)
 
     assert payment_account[0] == '0x0000000000000000000000000000000000000000'
 
+
 '''
 TEST3_支払情報を警告状態にする(warn)
 '''
+
+
 # 正常系1: 新規登録 -> 警告
 def test_warn_normal_1(web3, chain, users):
     admin = users['admin']
@@ -357,7 +374,8 @@ def test_warn_normal_1(web3, chain, users):
     assert payment_account[3] == 3
 
     # 認可状態が未認可の状態であることを確認
-    assert account_approved == False
+    assert account_approved is False
+
 
 # エラー系1: 入力値の型誤り
 def test_warn_error_1(web3, chain, users):
@@ -374,6 +392,7 @@ def test_warn_error_1(web3, chain, users):
     with pytest.raises(TypeError):
         pg_contract.transact().warn(trader)
 
+
 # エラー系2: 登録なし -> 警告
 def test_warn_error_2(web3, chain, users):
     admin = users['admin']
@@ -386,15 +405,18 @@ def test_warn_error_2(web3, chain, users):
 
     # 警告 -> Failure
     web3.eth.defaultAccount = agent
-    txn_hash = pg_contract.transact().warn(trader)
+    pg_contract.transact().warn(trader)
 
     payment_account = pg_contract.call().payment_accounts(trader, agent)
 
     assert payment_account[0] == '0x0000000000000000000000000000000000000000'
 
+
 '''
 TEST4_支払情報を非承認にする(unapprove)
 '''
+
+
 # 正常系1: 新規登録 -> 非承認
 def test_unapprove_normal_1(web3, chain, users):
     admin = users['admin']
@@ -430,7 +452,8 @@ def test_unapprove_normal_1(web3, chain, users):
     assert payment_account[3] == 1
 
     # 認可状態が未認可の状態であることを確認
-    assert account_approved == False
+    assert account_approved is False
+
 
 # 正常系2: 新規登録 -> 承認 -> 非承認
 # 認可状態が未認可の状態に戻る
@@ -473,7 +496,8 @@ def test_unapprove_normal_2(web3, chain, users):
     assert payment_account[3] == 1
 
     # 認可状態が未認可の状態であることを確認
-    assert account_approved == False
+    assert account_approved is False
+
 
 # エラー系1: 入力値の型誤り
 def test_unapprove_error_1(web3, chain, users):
@@ -490,6 +514,7 @@ def test_unapprove_error_1(web3, chain, users):
     with pytest.raises(TypeError):
         pg_contract.transact().unapprove(trader)
 
+
 # エラー系2: 登録なし -> 非承認
 def test_unapprove_error_2(web3, chain, users):
     admin = users['admin']
@@ -502,15 +527,18 @@ def test_unapprove_error_2(web3, chain, users):
 
     # 非承認 -> Failure
     web3.eth.defaultAccount = agent
-    txn_hash = pg_contract.transact().unapprove(trader)
+    pg_contract.transact().unapprove(trader)
 
     payment_account = pg_contract.call().payment_accounts(trader, agent)
 
     assert payment_account[0] == '0x0000000000000000000000000000000000000000'
 
+
 '''
 TEST5_支払情報をBAN状態にする(ban)
 '''
+
+
 # 正常系1: 新規登録 -> BAN
 def test_ban_normal_1(web3, chain, users):
     admin = users['admin']
@@ -546,7 +574,8 @@ def test_ban_normal_1(web3, chain, users):
     assert payment_account[3] == 4
 
     # 認可状態が未認可の状態であることを確認
-    assert account_approved == False
+    assert account_approved is False
+
 
 # エラー系1: 入力値の型誤り
 def test_ban_error_1(web3, chain, users):
@@ -563,6 +592,7 @@ def test_ban_error_1(web3, chain, users):
     with pytest.raises(TypeError):
         pg_contract.transact().ban(trader)
 
+
 # エラー系2: 登録なし -> BAN
 def test_ban_error_2(web3, chain, users):
     admin = users['admin']
@@ -575,15 +605,18 @@ def test_ban_error_2(web3, chain, users):
 
     # BAN -> Failure
     web3.eth.defaultAccount = agent
-    txn_hash = pg_contract.transact().ban(trader)
+    pg_contract.transact().ban(trader)
 
     payment_account = pg_contract.call().payment_accounts(trader, agent)
 
     assert payment_account[0] == '0x0000000000000000000000000000000000000000'
 
+
 '''
 TEST6_収納代行業者（Agent）の追加（addAgent）
 '''
+
+
 # 正常系1: 新規登録
 def test_addAgent_normal_1(web3, chain, users):
     admin = users['admin']
@@ -601,6 +634,7 @@ def test_addAgent_normal_1(web3, chain, users):
     agents = pg_contract.call().getAgents()
     assert agents[0] == agent
     assert len(agents) == 30
+
 
 # 正常系2: 登録２回
 def test_addAgent_normal_2(web3, chain, users):
@@ -625,6 +659,7 @@ def test_addAgent_normal_2(web3, chain, users):
     assert agents[0] == agent
     assert len(agents) == 30
 
+
 # エラー系1: 入力値の型誤り（agent_id）
 def test_addAgent_error_1(web3, chain, users):
     admin = users['admin']
@@ -639,6 +674,7 @@ def test_addAgent_error_1(web3, chain, users):
     with pytest.raises(TypeError):
         pg_contract.transact().addAgent('0', agent)
 
+
 # エラー系2: 入力値の型誤り（agent_address）
 def test_addAgent_error_2(web3, chain, users):
     admin = users['admin']
@@ -652,6 +688,7 @@ def test_addAgent_error_2(web3, chain, users):
     web3.eth.defaultAccount = admin
     with pytest.raises(TypeError):
         pg_contract.transact().addAgent(0, agent)
+
 
 # エラー系3: リスト上限超
 def test_addAgent_error_3(web3, chain, users):
@@ -672,9 +709,12 @@ def test_addAgent_error_3(web3, chain, users):
         assert agent_address == '0x0000000000000000000000000000000000000000'
     assert len(agents) == 30
 
+
 '''
 TEST7_利用規約登録（addTerms）
 '''
+
+
 # 正常系1: 新規登録
 def test_addTerms_normal_1(web3, chain, users):
     admin = users['admin']
@@ -693,8 +733,9 @@ def test_addTerms_normal_1(web3, chain, users):
     terms = pg_contract.call().terms(agent, latest_terms_version - 1)
 
     assert terms[0] == terms_text
-    assert terms[1] == True
+    assert terms[1] is True
     assert latest_terms_version == 1
+
 
 # 正常系2: 登録２回
 def test_addTerms_normal_2(web3, chain, users):
@@ -720,12 +761,13 @@ def test_addTerms_normal_2(web3, chain, users):
     terms2 = pg_contract.call().terms(agent, latest_terms_version - 1)
 
     assert terms1[0] == terms_text
-    assert terms1[1] == True
+    assert terms1[1] is True
 
     assert terms2[0] == terms_text_after
-    assert terms2[1] == True
+    assert terms2[1] is True
 
     assert latest_terms_version == 2
+
 
 # エラー系1: 入力値の型誤り
 def test_addTerms_error_1(web3, chain, users):
@@ -741,9 +783,12 @@ def test_addTerms_error_1(web3, chain, users):
     with pytest.raises(TypeError):
         pg_contract.transact().addTerms(1234)
 
+
 '''
 TEST8_利用規約同意（agreeTerms）
 '''
+
+
 # 正常系1: 同意
 def test_agreeTerms_normal_1(web3, chain, users):
     admin = users['admin']
@@ -775,10 +820,11 @@ def test_agreeTerms_normal_1(web3, chain, users):
     # 規約同意情報の内容が正しいことを確認
     assert agreement[0] == trader
     assert agreement[1] == agent
-    assert agreement[2] == True
+    assert agreement[2] is True
 
     # 利用規約同意状態（最新版）が同意済であることを確認
-    assert is_agreed == True
+    assert is_agreed is True
+
 
 # エラー系1: 入力値の型誤り
 def test_agreeTerms_error_1(web3, chain, users):
@@ -793,6 +839,7 @@ def test_agreeTerms_error_1(web3, chain, users):
     web3.eth.defaultAccount = trader
     with pytest.raises(TypeError):
         pg_contract.transact().agreeTerms(1234)
+
 
 # エラー系2: 利用規約未登録 => 利用規約同意
 def test_agreeTerms_error_2(web3, chain, users):
@@ -815,7 +862,7 @@ def test_agreeTerms_error_2(web3, chain, users):
     # 規約同意情報の内容が正しいことを確認
     assert agreement[0] == '0x0000000000000000000000000000000000000000'
     assert agreement[1] == '0x0000000000000000000000000000000000000000'
-    assert agreement[2] == False
+    assert agreement[2] is False
 
     # 利用規約同意状態（最新版）が未同意であることを確認
-    assert is_agreed == False
+    assert is_agreed is False

--- a/tests/test_personalinfo.py
+++ b/tests/test_personalinfo.py
@@ -7,11 +7,12 @@ encrypted_message_after = 'encrypted_message_after'
 TEST1_個人情報を登録（register）
 '''
 
+
 # 正常系1: 新規登録
 def test_register_normal_1(web3, chain, users):
     admin_address = users['admin']
     account_address = users['trader']
-    link_address = users['issuer'] # issuerのアドレスに公開する
+    link_address = users['issuer']  # issuerのアドレスに公開する
 
     web3.eth.defaultAccount = admin_address
     personalinfo_contract, _ = chain.provider.get_or_deploy_contract('PersonalInfo')
@@ -29,14 +30,13 @@ def test_register_normal_1(web3, chain, users):
     assert personal_info[2] == encrypted_message
 
     # 登録状態が登録済みの状態であることを確認
-    assert is_registered == True
+    assert is_registered is True
 
 
 # 正常系2: 上書き登録
 def test_register_normal_2(web3, chain, users):
-    admin_address = users['admin']
     account_address = users['trader']
-    link_address = users['issuer'] # issuerのアドレスに公開する
+    link_address = users['issuer']  # issuerのアドレスに公開する
 
     web3.eth.defaultAccount = account_address
     personalinfo_contract, _ = chain.provider.get_or_deploy_contract('PersonalInfo')
@@ -59,14 +59,14 @@ def test_register_normal_2(web3, chain, users):
     assert personal_info[2] == encrypted_message_after
 
     # 登録状態が登録済みの状態であることを確認
-    assert is_registered == True
+    assert is_registered is True
 
 
 # 正常系3: 未登録のアドレスの情報参照
 def test_register_normal_3(web3, chain, users):
     admin_address = users['admin']
     account_address = users['trader']
-    link_address = users['issuer'] # issuerのアドレスに公開する
+    link_address = users['issuer']  # issuerのアドレスに公開する
 
     web3.eth.defaultAccount = admin_address
     personalinfo_contract, _ = chain.provider.get_or_deploy_contract('PersonalInfo')
@@ -80,7 +80,7 @@ def test_register_normal_3(web3, chain, users):
     assert personal_info[2] == ''
 
     # 登録状態が登録済みの状態であることを確認
-    assert is_registered == False
+    assert is_registered is False
 
 
 # エラー系1: 入力値の型誤り（発行体アドレス）
@@ -95,16 +95,14 @@ def test_register_error_1(web3, chain, users):
     # 登録 -> Failure
     web3.eth.defaultAccount = account_address
     with pytest.raises(TypeError):
-        personalinfo_contract.transact().register(link_address,encrypted_message)
+        personalinfo_contract.transact().register(link_address, encrypted_message)
 
 
 # エラー系2: 入力値の型誤り（暗号化情報）
 def test_register_error_2(web3, chain, users):
     admin_address = users['admin']
     account_address = users['trader']
-    link_address = users['issuer'] # issuerのアドレスに公開する
-
-    encrypted_message = 1234
+    link_address = users['issuer']  # issuerのアドレスに公開する
 
     web3.eth.defaultAccount = admin_address
     personalinfo_contract, _ = chain.provider.get_or_deploy_contract('PersonalInfo')
@@ -112,4 +110,4 @@ def test_register_error_2(web3, chain, users):
     # 登録 -> Failure
     web3.eth.defaultAccount = account_address
     with pytest.raises(TypeError):
-        personalinfo_contract.transact().register(link_address,encrypted_message)
+        personalinfo_contract.transact().register(link_address, 1234)

--- a/tests/test_tokenlist.py
+++ b/tests/test_tokenlist.py
@@ -1,5 +1,4 @@
 import pytest
-from ethereum.tester import TransactionFailed
 from eth_utils import to_checksum_address
 import utils
 
@@ -8,6 +7,8 @@ token_template = 'some_template'
 '''
 TEST1_トークン情報を登録（register）
 '''
+
+
 # 正常系1: 新規登録(普通社債Token)
 def test_register_normal_1(web3, chain, users, bond_exchange):
     admin = users['admin']
@@ -46,6 +47,7 @@ def test_register_normal_1(web3, chain, users, bond_exchange):
     assert token_by_num[0] == to_checksum_address(token_address)
     assert token_by_num[1] == token_template
     assert token_by_num[2] == to_checksum_address(issuer)
+
 
 # 正常系2: 新規登録（クーポンToken）
 def test_register_normal_2(web3, chain, users, coupon_exchange):
@@ -86,6 +88,7 @@ def test_register_normal_2(web3, chain, users, coupon_exchange):
     assert token_by_num[1] == token_template
     assert token_by_num[2] == to_checksum_address(issuer)
 
+
 # エラー系1: トークンアドレスの型（address）が正しくない場合
 def test_register_error_1(web3, chain, users):
     admin = users['admin']
@@ -100,6 +103,7 @@ def test_register_error_1(web3, chain, users):
     token_address = 'some_token_address'
     with pytest.raises(TypeError):
         tokenlist_contract.transact().register(token_address, token_template)
+
 
 # エラー系2: トークンテンプレートの型（string）が正しくない場合
 def test_register_error_2(web3, chain, users, bond_exchange):
@@ -118,9 +122,9 @@ def test_register_error_2(web3, chain, users, bond_exchange):
 
     # 新規登録 -> Failure
     web3.eth.defaultAccount = issuer
-    token_template = 1234
     with pytest.raises(TypeError):
-        tokenlist_contract.transact().register(token_address, token_template)
+        tokenlist_contract.transact().register(token_address, 1234)
+
 
 # エラー系3: 同一トークンを複数回登録
 def test_register_error_3(web3, chain, users, bond_exchange):
@@ -162,6 +166,7 @@ def test_register_error_3(web3, chain, users, bond_exchange):
     assert token_by_num[0] == to_checksum_address(token_address)
     assert token_by_num[1] == token_template
     assert token_by_num[2] == to_checksum_address(issuer)
+
 
 # エラー系4: 異なるアドレスから同一トークンを登録
 def test_register_error_4(web3, chain, users, bond_exchange):
@@ -208,6 +213,8 @@ def test_register_error_4(web3, chain, users, bond_exchange):
 '''
 TEST2_オーナーを変更（changeOwner）
 '''
+
+
 # 正常系1: オーナー変更
 def test_changeOwner_normal_1(web3, chain, users, bond_exchange):
     admin = users['admin']
@@ -254,10 +261,10 @@ def test_changeOwner_normal_1(web3, chain, users, bond_exchange):
     assert token_by_num[1] == token_template
     assert token_by_num[2] == to_checksum_address(new_owner_address)
 
+
 # エラー系1: トークンアドレスの型（address）が正しくない場合
 def test_changeOwner_error_1(web3, chain, users):
     admin = users['admin']
-    issuer = users['issuer']
     new_owner_address = admin
 
     # TokenListコントラクト作成
@@ -270,11 +277,11 @@ def test_changeOwner_error_1(web3, chain, users):
     with pytest.raises(TypeError):
         tokenlist_contract.transact().changeOwner(token_address, new_owner_address)
 
+
 # エラー系2: オーナーアドレスの型（address）が正しくない場合
 def test_changeOwner_error_2(web3, chain, users, bond_exchange):
     admin = users['admin']
     issuer = users['issuer']
-    new_owner_address = admin
 
     # TokenListコントラクト作成
     web3.eth.defaultAccount = admin
@@ -291,6 +298,7 @@ def test_changeOwner_error_2(web3, chain, users, bond_exchange):
     # 新規登録 -> Failure
     with pytest.raises(TypeError):
         tokenlist_contract.transact().changeOwner(token_address, new_owner_address)
+
 
 # エラー系3: 登録なし -> オーナー変更
 def test_changeOwner_error_3(web3, chain, users, bond_exchange):
@@ -315,6 +323,7 @@ def test_changeOwner_error_3(web3, chain, users, bond_exchange):
 
     owner_address = tokenlist_contract.call().getOwnerAddress(token_address)
     assert owner_address == '0x0000000000000000000000000000000000000000'
+
 
 # エラー系4: オーナー権限のないアドレスでオーナー変更を実施した場合
 def test_changeOwner_error_4(web3, chain, users, bond_exchange):


### PR DESCRIPTION
close #92 

- exchangeコントラクトの取引情報を格納するためのEternal Storage（ExchangeStorage）を実装

- 各ExchangeからExchangeStorageを利用するように変更

- テストケースを修正

- その他リファクタリング