### PR TITLE
fix: change transferable default setting

### DIFF
--- a/contracts/IbetStraightBond.sol
+++ b/contracts/IbetStraightBond.sol
@@ -77,7 +77,7 @@ contract IbetStraightBond is Ownable, IbetStandardTokenInterface {
     returnAmount = _returnAmount;
     purpose = _purpose;
     memo = _memo;
-    transferable = false;
+    transferable = true;
     balances[owner] = totalSupply;
     isRedeemed = false;
     contactInformation = _contactInformation;

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -63,11 +63,6 @@ def issue_transferable_bond_token(web3,chain,users,exchange_address):
         deploy_args = deploy_args
     )
 
-    # 譲渡可能更新
-    web3.eth.defaultAccount = users['issuer']
-    txn_hash = bond_token.transact().setTransferable(True)
-    chain.wait.for_receipt(txn_hash)
-
     return bond_token, deploy_args
 
 # 会員権（譲渡可能）新規発行


### PR DESCRIPTION
close #147 

債券コントラクトの譲渡可否区分のデフォルト設定値を「譲渡可能」に設定変更しました。