### PR TITLE
hardhat: Allow blocks with same timestamp

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -7,7 +7,8 @@ module.exports = {
       blockGasLimit: 800000000,
       hardfork: "berlin",
       throwOnTransactionFailures: false,
-      throwOnCallFailures: false
+      throwOnCallFailures: false,
+      allowBlocksWithSameTimestamp: true
     },
   },
   solidity: "0.8.23",


### PR DESCRIPTION
Hardhat does not allow the same block timestamp by default, which is different from Ganache's behavior. As a result of this, if many transactions are executed in a unit test, the timestamp set will be a "future timestamp" and the unit test may behave unexpectedly.
This PR improves this problem.

Ref: https://hardhat.org/hardhat-network/docs/reference#allowblockswithsametimestamp
