### PR TITLE
Add forceChangeLockedAccount function to manage locked accounts

### DIFF
--- a/contracts/token/IbetShare.sol
+++ b/contracts/token/IbetShare.sol
@@ -351,6 +351,44 @@ contract IbetShare is Ownable, IbetSecurityTokenInterface {
         );
     }
 
+    /// @notice ロック対象のアドレスを強制変更する
+    /// @dev 発行体のみ実行可能
+    /// @param _lockAddress 資産ロック先アドレス
+    /// @param _beforeAccountAddress 以前のロック対象アドレス
+    /// @param _afterAccountAddress 新しいロック対象アドレス
+    /// @param _value ロック対象を変更する数量
+    /// @param _data イベント出力用の任意のデータ
+    function forceChangeLockedAccount(
+        address _lockAddress,
+        address _beforeAccountAddress,
+        address _afterAccountAddress,
+        uint256 _value,
+        string memory _data
+    ) public override onlyOwner {
+        // 変更数量がもともとのロック数量を上回ってる場合、エラーを返す
+        if (lockedOf(_lockAddress, _beforeAccountAddress) < _value)
+            revert(ErrorCode.ERR_IbetShare_forceChangeLockedAccount_111701);
+
+        // データ更新
+        locked[_lockAddress][_beforeAccountAddress] = lockedOf(
+            _lockAddress,
+            _beforeAccountAddress
+        ).sub(_value);
+        locked[_lockAddress][_afterAccountAddress] = lockedOf(
+            _lockAddress,
+            _afterAccountAddress
+        ).add(_value);
+
+        // イベント登録
+        emit ForceChangeLockedAccount(
+            _lockAddress,
+            _beforeAccountAddress,
+            _afterAccountAddress,
+            _value,
+            _data
+        );
+    }
+
     /// @notice コントラクトアドレス判定
     /// @param _addr アドレス
     /// @return is_contract 判定結果

--- a/contracts/token/IbetStraightBond.sol
+++ b/contracts/token/IbetStraightBond.sol
@@ -655,6 +655,46 @@ contract IbetStraightBond is Ownable, IbetSecurityTokenInterface {
         );
     }
 
+    /// @notice ロック対象のアドレスを強制変更する
+    /// @dev 発行体のみ実行可能
+    /// @param _lockAddress 資産ロック先アドレス
+    /// @param _beforeAccountAddress 以前のロック対象アドレス
+    /// @param _afterAccountAddress 新しいロック対象アドレス
+    /// @param _value ロック対象を変更する数量
+    /// @param _data イベント出力用の任意のデータ
+    function forceChangeLockedAccount(
+        address _lockAddress,
+        address _beforeAccountAddress,
+        address _afterAccountAddress,
+        uint256 _value,
+        string memory _data
+    ) public override onlyOwner {
+        // 変更数量がもともとのロック数量を上回ってる場合、エラーを返す
+        if (lockedOf(_lockAddress, _beforeAccountAddress) < _value)
+            revert(
+                ErrorCode.ERR_IbetStraightBond_forceChangeLockedAccount_121701
+            );
+
+        // データ更新
+        locked[_lockAddress][_beforeAccountAddress] = lockedOf(
+            _lockAddress,
+            _beforeAccountAddress
+        ).sub(_value);
+        locked[_lockAddress][_afterAccountAddress] = lockedOf(
+            _lockAddress,
+            _afterAccountAddress
+        ).add(_value);
+
+        // イベント登録
+        emit ForceChangeLockedAccount(
+            _lockAddress,
+            _beforeAccountAddress,
+            _afterAccountAddress,
+            _value,
+            _data
+        );
+    }
+
     /// @notice 移転申請
     /// @param _to 移転先アドレス
     /// @param _value 移転数量

--- a/contracts/utils/Errors.sol
+++ b/contracts/utils/Errors.sol
@@ -75,6 +75,8 @@ library ErrorCode {
     string constant ERR_IbetShare_bulkTransferFrom_111501 = "111501";
     // IbetShare_forceLock
     string constant ERR_IbetShare_forceLock_111601 = "111601";
+    // IbetShare_forceChangeLockedAccount
+    string constant ERR_IbetShare_forceChangeLockedAccount_111701 = "111701";
 
     // 12XXXX
     // IbetStraightBond_lock
@@ -122,6 +124,9 @@ library ErrorCode {
     string constant ERR_IbetStraightBond_bulkTransferFrom_121501 = "121501";
     // IbetStraightBond_forceLock
     string constant ERR_IbetStraightBond_forceLock_121601 = "121601";
+    // IbetStraightBond_forceChangeLockedAccount
+    string constant ERR_IbetStraightBond_forceChangeLockedAccount_121701 =
+        "121701";
 
     // 13XXXX
     // IbetCoupon_transferToContract

--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -162,6 +162,11 @@ Developers will receive error msg as code, and each error code is described belo
 |------------|-----------------------------------------------------|-----------------|
 | **111601** | Lock amount is greater than message sender balance. | -               |
 
+#### forceChangeLockedAccount (1117XX)
+| Code       | Situation                         | Possible causes |
+|------------|-----------------------------------|-----------------|
+| **111701** | Locked balance is not sufficient. | -               |
+
 ### IbetStraightBond (12XXXX)
 
 #### lock (1200XX)
@@ -275,6 +280,11 @@ Developers will receive error msg as code, and each error code is described belo
 | Code       | Situation                                           | Possible causes | 
 |------------|-----------------------------------------------------|-----------------|
 | **121601** | Lock amount is greater than message sender balance. | -               |
+
+#### forceChangeLockedAccount (1217XX)
+| Code       | Situation                         | Possible causes |
+|------------|-----------------------------------|-----------------|
+| **121701** | Locked balance is not sufficient. | -               |
 
 ### IbetCoupon (13XXXX)
 

--- a/interfaces/IbetSecurityTokenInterface.sol
+++ b/interfaces/IbetSecurityTokenInterface.sol
@@ -214,11 +214,26 @@ abstract contract IbetSecurityTokenInterface is IbetStandardTokenInterface {
     /// @param _lockAddress 資産ロック先アドレス
     /// @param _accountAddress アンロック対象のアドレス
     /// @param _recipientAddress 受取アドレス
+    /// @param _value アンロックする数量
     /// @param _data イベント出力用の任意のデータ
     function forceUnlock(
         address _lockAddress,
         address _accountAddress,
         address _recipientAddress,
+        uint256 _value,
+        string memory _data
+    ) public virtual;
+
+    /// @notice ロック対象のアドレスを強制変更する
+    /// @param _lockAddress 資産ロック先アドレス
+    /// @param _beforeAccountAddress 以前のロック対象アドレス
+    /// @param _afterAccountAddress 新しいロック対象アドレス
+    /// @param _value ロック対象を変更する数量
+    /// @param _data イベント出力用の任意のデータ
+    function forceChangeLockedAccount(
+        address _lockAddress,
+        address _beforeAccountAddress,
+        address _afterAccountAddress,
         uint256 _value,
         string memory _data
     ) public virtual;
@@ -262,6 +277,15 @@ abstract contract IbetSecurityTokenInterface is IbetStandardTokenInterface {
         address indexed accountAddress,
         address indexed lockAddress,
         address recipientAddress,
+        uint256 value,
+        string data
+    );
+
+    /// Event: ロック対象アドレス強制変更
+    event ForceChangeLockedAccount(
+        address indexed lockAddress,
+        address indexed beforeAccountAddress,
+        address indexed afterAccountAddress,
         uint256 value,
         string data
     );


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces a new feature, `forceChangeLockedAccount`, across multiple contracts (`IbetShare`, `IbetStraightBond`) and updates related interfaces, error codes, and tests. This feature allows the issuer to forcibly change the locked account associated with a specific asset.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #472

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Interface Updates:

* **Interface Extension**: Updated the `IbetSecurityTokenInterface` to include the new `forceChangeLockedAccount` function and its associated event declaration. [[1]](diffhunk://#diff-270f57dc8a6d1a31766651c0cf70931189e9d1c404a2ff44e6015484c954f2c4R227-R240) [[2]](diffhunk://#diff-270f57dc8a6d1a31766651c0cf70931189e9d1c404a2ff44e6015484c954f2c4R284-R292)

New function: 
```solidity
    /// @notice ロック対象のアドレスを強制変更する
    /// @param _lockAddress 資産ロック先アドレス
    /// @param _beforeAccountAddress 以前のロック対象アドレス
    /// @param _afterAccountAddress 新しいロック対象アドレス
    /// @param _value ロック対象を変更する数量
    /// @param _data イベント出力用の任意のデータ
    function forceChangeLockedAccount(
        address _lockAddress,
        address _beforeAccountAddress,
        address _afterAccountAddress,
        uint256 _value,
        string memory _data
    ) public virtual;
```

New event:
```solidity
    /// Event: ロック対象アドレス強制変更
    event ForceChangeLockedAccount(
        address indexed lockAddress,
        address indexed beforeAccountAddress,
        address indexed afterAccountAddress,
        uint256 value,
        string data
    );
```

### Feature Implementation:

* **`forceChangeLockedAccount` Functionality**: Added the `forceChangeLockedAccount` function to `IbetShare` and `IbetStraightBond` contracts, enabling the issuer to update locked accounts while ensuring proper error handling for insufficient locked balances. [[1]](diffhunk://#diff-2633dfc3e5cd647c41ab0d019852e75ca0a167c580dd15a3ed69c0106ac72468R354-R391) [[2]](diffhunk://#diff-d11c7173cecf7e402ae632f711f46c2c4e3ad30a66b906735a0e26d236db38fbR658-R697)

### Error Code Updates:

* **New Error Codes**: Added specific error codes for `forceChangeLockedAccount` in the `ErrorCode` library to handle insufficient locked balances for both `IbetShare` and `IbetStraightBond`. [[1]](diffhunk://#diff-41e3c405851499899c192341a0bd4b5587ba64730ba738b5db5ebba0a08de5c2R78-R79) [[2]](diffhunk://#diff-41e3c405851499899c192341a0bd4b5587ba64730ba738b5db5ebba0a08de5c2R127-R129)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
