### PR TITLE
Fix linting configuration to use ruff instead of black

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,12 +2,12 @@ name: Pull Request Check
 on: [pull_request]
 
 jobs:
-  lint-black:
-    name: "Lint check (black)"
+  lint-ruff:
+    name: "Lint check (ruff)"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: psf/black@stable
+      - uses: astral-sh/ruff-action@v3
   lint-prettier:
     name: "Lint check (prettier)"
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.4
+    rev: v0.11.13
     hooks:
       - id: ruff-format
         name: ruff-format


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->
This pull request updates the linting tools used in the project workflow and pre-commit configuration, replacing `black` with `ruff` for Python linting and upgrading the `ruff` version.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- None

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Workflow updates:
* [`.github/workflows/pr.yml`](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L5-R10): Replaced the `black` linting job with `ruff` in the pull request workflow, updating the corresponding GitHub Action to `astral-sh/ruff-action@v3`.

### Pre-commit configuration updates:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L3-R3): Upgraded the `ruff` version from `v0.5.4` to `v0.11.13` in the pre-commit hooks.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
