### PR TITLE
Add P256 wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,6 @@ You will need to deploy them in a different way.
 ### Network(hardhat) settings
 Network settings are defined in the `hardhat.config.js` file.
 
-- chainId: 2017
-- gasPrice: 0
-- blockGasLimit: 800000000
-- hardfork: "berlin"
-
 When developing in a local environment, start and use the `hardhat-network` container defined in `docker-compose.yml`. 
 By default, the RPC service starts on port 8545.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # ibet Smart Contract
 
 <p>
-  <img alt="Version" src="https://img.shields.io/badge/version-26.3-blue.svg?cacheSeconds=2592000" />
+  <img alt="Version" src="https://img.shields.io/badge/version-26.6-blue.svg?cacheSeconds=2592000" />
   <img alt="License: Apache--2.0" src="https://img.shields.io/badge/License-Apache--2.0-yellow.svg" />
 </p>
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -139,11 +139,6 @@ $ ./scripts/deploy_shared_contract.sh {--payment_gateway 0xabcd...} {contract_na
 
 ネットワーク設定は `hardhat.config.js` ファイルに定義されています。
 
-- chainId: 2017
-- gasPrice: 0
-- blockGasLimit: 800000000
-- hardfork: "berlin"
-
 ローカル環境で開発を行う際は、`docker-compose.yml` に定義されている、`hardhat-network` コンテナを起動して利用してください。
 デフォルトでは 8545 ポートで RPC サービスが起動します。
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,7 +5,7 @@
 # ibet Smart Contract
 
 <p>
-  <img alt="Version" src="https://img.shields.io/badge/version-26.3-blue.svg?cacheSeconds=2592000" />
+  <img alt="Version" src="https://img.shields.io/badge/version-26.6-blue.svg?cacheSeconds=2592000" />
   <img alt="License: Apache--2.0" src="https://img.shields.io/badge/License-Apache--2.0-yellow.svg" />
 </p>
 

--- a/contracts/utils/Errors.sol
+++ b/contracts/utils/Errors.sol
@@ -338,4 +338,11 @@ library ErrorCode {
     // 62XXXX
     // FreezeLog_updateLog
     string constant ERR_FreezeLog_updateLog_620001 = "620001";
+
+    // 63XXXX
+    // P256Wallet_constructor
+    string constant ERR_P256Wallet_constructor_630001 = "630001";
+    // P256Wallet_execute
+    string constant ERR_P256Wallet_execute_630101 = "630101";
+    string constant ERR_P256Wallet_execute_630102 = "630102";
 }

--- a/contracts/utils/P256Wallet.sol
+++ b/contracts/utils/P256Wallet.sol
@@ -1,0 +1,130 @@
+/**
+ * Copyright BOOSTRY Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+pragma solidity ^0.8.23;
+
+/// @title P256 Wallet (EIP-7951 precompile based)
+/// @notice A minimal contract wallet that verifies secp256r1(P-256) signatures
+///         through the EIP-7951-compatible precompile and executes transactions.
+contract P256Wallet {
+    // NOTE:
+    // The precompile address follows the expected EIP-7951 deployment on ibet quorum.
+    // If the chain uses a different address, this constant can be adjusted.
+    address internal constant P256_VERIFY_PRECOMPILE =
+        0x0000000000000000000000000000000000000100;
+
+    uint256 public immutable pubKeyX;
+    uint256 public immutable pubKeyY;
+
+    uint256 public nonce;
+
+    event Executed(
+        address indexed target,
+        uint256 value,
+        bytes data,
+        bytes returnData,
+        uint256 nonce
+    );
+
+    error InvalidPublicKey();
+    error InvalidSignature();
+    error ExecutionFailed();
+
+    constructor(uint256 _pubKeyX, uint256 _pubKeyY) {
+        if (_pubKeyX == 0 || _pubKeyY == 0) {
+            revert InvalidPublicKey();
+        }
+        pubKeyX = _pubKeyX;
+        pubKeyY = _pubKeyY;
+    }
+
+    receive() external payable {}
+
+    /// @notice Execute a transaction authorized by a P-256 signature.
+    /// @param target Destination contract/account.
+    /// @param value Native token amount to transfer.
+    /// @param data Calldata for the call.
+    /// @param sigR ECDSA signature r.
+    /// @param sigS ECDSA signature s.
+    /// @return returnData Raw return data from target call.
+    function execute(
+        address target,
+        uint256 value,
+        bytes calldata data,
+        uint256 sigR,
+        uint256 sigS
+    ) external payable returns (bytes memory returnData) {
+        bytes32 txHash = getTransactionHash(target, value, data, nonce);
+
+        if (!_verify(txHash, sigR, sigS)) {
+            revert InvalidSignature();
+        }
+
+        uint256 currentNonce = nonce;
+        nonce = currentNonce + 1;
+
+        (bool success, bytes memory result) = target.call{value: value}(data);
+        if (!success) {
+            revert ExecutionFailed();
+        }
+
+        emit Executed(target, value, data, result, currentNonce);
+        return result;
+    }
+
+    /// @notice Build the signed hash for execution authorization.
+    function getTransactionHash(
+        address target,
+        uint256 value,
+        bytes calldata data,
+        uint256 _nonce
+    ) public view returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked(
+                    bytes1(0x19),
+                    bytes1(0x01),
+                    block.chainid,
+                    address(this),
+                    target,
+                    value,
+                    keccak256(data),
+                    _nonce
+                )
+            );
+    }
+
+    /// @dev Calls EIP-7951-compatible precompile with input (hash, r, s, x, y).
+    ///      The precompile is expected to return 32-byte boolean-style value.
+    function _verify(
+        bytes32 hash,
+        uint256 sigR,
+        uint256 sigS
+    ) internal view returns (bool) {
+        bytes memory input = abi.encode(hash, sigR, sigS, pubKeyX, pubKeyY);
+        (bool success, bytes memory output) = P256_VERIFY_PRECOMPILE.staticcall(
+            input
+        );
+
+        if (!success || output.length < 32) {
+            return false;
+        }
+
+        return abi.decode(output, (uint256)) == 1;
+    }
+}

--- a/contracts/utils/P256Wallet.sol
+++ b/contracts/utils/P256Wallet.sol
@@ -18,6 +18,8 @@
  */
 pragma solidity ^0.8.23;
 
+import "./Errors.sol";
+
 /// @title P256 Wallet (EIP-7951 precompile based)
 /// @notice A minimal contract wallet that verifies secp256r1(P-256) signatures
 ///         through the EIP-7951-compatible precompile and executes transactions.
@@ -41,13 +43,9 @@ contract P256Wallet {
         uint256 nonce
     );
 
-    error InvalidPublicKey();
-    error InvalidSignature();
-    error ExecutionFailed();
-
     constructor(uint256 _pubKeyX, uint256 _pubKeyY) {
         if (_pubKeyX == 0 || _pubKeyY == 0) {
-            revert InvalidPublicKey();
+            revert(ErrorCode.ERR_P256Wallet_constructor_630001);
         }
         pubKeyX = _pubKeyX;
         pubKeyY = _pubKeyY;
@@ -72,7 +70,7 @@ contract P256Wallet {
         bytes32 txHash = getTransactionHash(target, value, data, nonce);
 
         if (!_verify(txHash, sigR, sigS)) {
-            revert InvalidSignature();
+            revert(ErrorCode.ERR_P256Wallet_execute_630101);
         }
 
         uint256 currentNonce = nonce;
@@ -80,7 +78,7 @@ contract P256Wallet {
 
         (bool success, bytes memory result) = target.call{value: value}(data);
         if (!success) {
-            revert ExecutionFailed();
+            revert(ErrorCode.ERR_P256Wallet_execute_630102);
         }
 
         emit Executed(target, value, data, result, currentNonce);

--- a/contracts/utils/WalletTestReceiver.sol
+++ b/contracts/utils/WalletTestReceiver.sol
@@ -1,0 +1,32 @@
+/**
+ * Copyright BOOSTRY Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+pragma solidity ^0.8.23;
+
+contract WalletTestReceiver {
+    uint256 public lastValue;
+    address public lastCaller;
+
+    event Updated(uint256 value, address caller);
+
+    function setValue(uint256 value) external {
+        lastValue = value;
+        lastCaller = msg.sender;
+        emit Updated(value, msg.sender);
+    }
+}

--- a/contracts/utils/WalletTestReceiver.sol
+++ b/contracts/utils/WalletTestReceiver.sol
@@ -29,4 +29,8 @@ contract WalletTestReceiver {
         lastCaller = msg.sender;
         emit Updated(value, msg.sender);
     }
+
+    function revertAlways() external pure {
+        revert("receiver error");
+    }
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -3,9 +3,10 @@ module.exports = {
   networks: {
     hardhat: {
       chainId: 2017,
+      blockGasLimit: 16777216,
+      hardfork: "osaka",
       gasPrice: 0,
-      blockGasLimit: 800000000,
-      hardfork: "berlin",
+      initialBaseFeePerGas: 0,
       throwOnTransactionFailures: false,
       throwOnCallFailures: false,
       allowBlocksWithSameTimestamp: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -2363,6 +2363,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2376,6 +2377,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ibet-SmartContract"
-version = "26.3"
+version = "26.6"
 authors = [
     {name = "BOOSTRY Co., Ltd.", email = "dev@boostry.co.jp"},
 ]

--- a/tests/utils/test_P256Wallet.py
+++ b/tests/utils/test_P256Wallet.py
@@ -1,3 +1,22 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
 import brownie
 import pytest
 from Crypto.Hash import SHA256
@@ -141,5 +160,27 @@ class TestExecute:
                 call_data,
                 0,
                 0,
+                {"from": users["user1"]},
+            )
+
+    # Error_2
+    # target call failure should revert with 630102
+    def test_error_2(self, P256Wallet, WalletTestReceiver, users):
+        admin = users["admin"]
+        receiver = admin.deploy(WalletTestReceiver)
+        call_data = receiver.revertAlways.encode_input()
+
+        private_key, pubkey_x, pubkey_y = _generate_p256_keypair()
+        wallet = admin.deploy(P256Wallet, pubkey_x, pubkey_y)
+        tx_hash = wallet.getTransactionHash.call(receiver.address, 0, call_data, 0)
+        sig_r, sig_s = _generate_p256_signature(private_key, tx_hash)
+
+        with brownie.reverts(revert_msg="630102"):
+            wallet.execute(
+                receiver.address,
+                0,
+                call_data,
+                sig_r,
+                sig_s,
                 {"from": users["user1"]},
             )

--- a/tests/utils/test_P256Wallet.py
+++ b/tests/utils/test_P256Wallet.py
@@ -6,18 +6,29 @@ from Crypto.Signature import DSS
 
 
 class _RawHash:
+    block_size = 64
     digest_size = 32
     oid = SHA256.new(b"").oid
 
     def __init__(self, data: bytes):
         self._data = data
 
+    @classmethod
+    def new(cls, data=b""):
+        return cls(data)
+
+    def update(self, data: bytes):
+        self._data += data
+
+    def copy(self):
+        return self.__class__(self._data)
+
     def digest(self):
         return self._data
 
 
 def _generate_p256_signature(private_key, tx_hash):
-    signer = DSS.new(private_key, "fips-186-3", encoding="binary")
+    signer = DSS.new(private_key, "deterministic-rfc6979", encoding="binary")
     if isinstance(tx_hash, (bytes, bytearray)):
         tx_hash_bytes = bytes(tx_hash)
     else:

--- a/tests/utils/test_P256Wallet.py
+++ b/tests/utils/test_P256Wallet.py
@@ -119,7 +119,10 @@ class TestExecute:
         assert receiver.lastValue() == value_to_set
         assert receiver.lastCaller() == wallet.address
         assert wallet.nonce() == 1
+
         assert tx.events["Executed"]["target"] == receiver.address
+        assert tx.events["Executed"]["value"] == 0
+        assert tx.events["Executed"]["data"] == call_data
         assert tx.events["Executed"]["nonce"] == 0
 
     # Error_1
@@ -131,7 +134,7 @@ class TestExecute:
 
         call_data = receiver.setValue.encode_input(999)
 
-        with brownie.reverts():
+        with brownie.reverts(revert_msg="630101"):
             wallet.execute(
                 receiver.address,
                 0,

--- a/tests/utils/test_P256Wallet.py
+++ b/tests/utils/test_P256Wallet.py
@@ -1,0 +1,131 @@
+import brownie
+import pytest
+from Crypto.Hash import SHA256
+from Crypto.PublicKey import ECC
+from Crypto.Signature import DSS
+
+
+class _RawHash:
+    digest_size = 32
+    oid = SHA256.new(b"").oid
+
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def digest(self):
+        return self._data
+
+
+def _generate_p256_signature(private_key, tx_hash):
+    signer = DSS.new(private_key, "fips-186-3", encoding="binary")
+    if isinstance(tx_hash, (bytes, bytearray)):
+        tx_hash_bytes = bytes(tx_hash)
+    else:
+        tx_hash_hex = tx_hash.hex() if hasattr(tx_hash, "hex") else str(tx_hash)
+        if tx_hash_hex.startswith("0x"):
+            tx_hash_hex = tx_hash_hex[2:]
+        tx_hash_bytes = bytes.fromhex(tx_hash_hex)
+
+    signature = signer.sign(_RawHash(tx_hash_bytes))
+
+    return (
+        int.from_bytes(signature[:32], byteorder="big"),
+        int.from_bytes(signature[32:], byteorder="big"),
+    )
+
+
+def _generate_p256_keypair():
+    private_key = ECC.generate(curve="P-256")
+    return private_key, int(private_key.pointQ.x), int(private_key.pointQ.y)
+
+
+# TEST_deploy
+class TestDeploy:
+    # Normal_1
+    def test_normal_1(self, P256Wallet, users):
+        admin = users["admin"]
+        pubkey_x = 1
+        pubkey_y = 2
+
+        wallet = admin.deploy(P256Wallet, pubkey_x, pubkey_y)
+
+        assert wallet.pubKeyX() == pubkey_x
+        assert wallet.pubKeyY() == pubkey_y
+        assert wallet.nonce() == 0
+
+    # Error_1
+    def test_error_1(self, P256Wallet, users):
+        admin = users["admin"]
+
+        with pytest.raises(ValueError):
+            admin.deploy(P256Wallet, 0, 2)
+
+        with pytest.raises(ValueError):
+            admin.deploy(P256Wallet, 2, 0)
+
+
+# TEST_getTransactionHash
+class TestGetTransactionHash:
+    # Normal_1
+    def test_normal_1(self, P256Wallet, users):
+        admin = users["admin"]
+        wallet = admin.deploy(P256Wallet, 10, 20)
+
+        target = users["user1"].address
+        value = 123
+        data = "0x11223344"
+        nonce = 7
+
+        tx_hash = wallet.getTransactionHash.call(target, value, data, nonce)
+
+        assert tx_hash != "0x" + "00" * 32
+
+
+# TEST_execute
+class TestExecute:
+    # Normal_1
+    # valid signature should succeed
+    def test_normal_1(self, P256Wallet, WalletTestReceiver, users):
+        admin = users["admin"]
+        receiver = admin.deploy(WalletTestReceiver)
+        value_to_set = 12345
+        call_data = receiver.setValue.encode_input(value_to_set)
+
+        private_key, pubkey_x, pubkey_y = _generate_p256_keypair()
+        wallet = admin.deploy(P256Wallet, pubkey_x, pubkey_y)
+        tx_hash = wallet.getTransactionHash.call(receiver.address, 0, call_data, 0)
+        sig_r, sig_s = _generate_p256_signature(private_key, tx_hash)
+
+        tx = wallet.execute(
+            receiver.address,
+            0,
+            call_data,
+            sig_r,
+            sig_s,
+            {"from": users["user1"]},
+        )
+
+        assert receiver.lastValue() == value_to_set
+        assert receiver.lastCaller() == wallet.address
+        assert wallet.nonce() == 1
+        assert tx.events["Executed"]["target"] == receiver.address
+        assert tx.events["Executed"]["nonce"] == 0
+
+    # Error_1
+    # invalid signature should always fail
+    def test_error_1(self, P256Wallet, WalletTestReceiver, users):
+        admin = users["admin"]
+        wallet = admin.deploy(P256Wallet, 1, 2)
+        receiver = admin.deploy(WalletTestReceiver)
+
+        call_data = receiver.setValue.encode_input(999)
+
+        with brownie.reverts():
+            wallet.execute(
+                receiver.address,
+                0,
+                call_data,
+                0,
+                0,
+                {"from": users["user1"]},
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -609,7 +609,7 @@ wheels = [
 
 [[package]]
 name = "ibet-smartcontract"
-version = "26.3"
+version = "26.6"
 source = { virtual = "." }
 dependencies = [
     { name = "eth-brownie" },


### PR DESCRIPTION
This pull request introduces a new minimal P-256 (secp256r1) signature-based contract wallet, adds a test receiver contract, and provides comprehensive tests for the new wallet.

## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #514

## 🔄 Changes

<!-- List the major changes in this PR. -->

**New contract functionality:**

* Added `P256Wallet` contract, a minimal smart contract wallet that verifies secp256r1 (P-256) signatures via an EIP-7951-compatible precompile and allows execution of transactions authorized by such signatures. The contract includes nonce management, signature verification, and emits execution events. (`contracts/utils/P256Wallet.sol`)
* Added `WalletTestReceiver` contract, a simple contract to facilitate wallet testing by recording the last value set and the caller. (`contracts/utils/WalletTestReceiver.sol`)

**Testing:**

* Added `test_P256Wallet.py` with extensive tests for deploying the wallet, signature verification, transaction execution, and error scenarios. Includes utilities for P-256 key generation and signature creation. (`tests/utils/test_P256Wallet.py`)

**Configuration and documentation updates:**

* Updated Hardhat network configuration to use the "osaka" hardfork, set a new gas limit, and adjusted other network parameters for compatibility. (`hardhat.config.js`)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
