### PR TITLE
Bump solc and pin GitHub Actions to specific commits

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -10,4 +10,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.2
+      - uses: kentaro-m/auto-assign-action@0a2c53d3721e4c5cfcce6afd4014aecc337979f6  # v2.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,6 +39,18 @@ jobs:
           version: stable
       - name: Install dependencies
         run: uv sync --frozen --no-install-project
+      - name: Install Solidity compiler
+        run: |
+          set -euo pipefail
+          solcx_dir="$HOME/.solcx"
+          temp_dir="$(mktemp -d)"
+          compiler_path="$temp_dir/solc-static-linux"
+          compiler_url="https://github.com/ethereum/solidity/releases/download/v0.8.34/solc-static-linux"
+          compiler_sha256="d40adc6f9fdbb22a97d32a02fa05688bf2ee7886affc48c9851b0afd4a726b39"
+          mkdir -p "$solcx_dir"
+          curl -fsSL "$compiler_url" -o "$compiler_path"
+          echo "$compiler_sha256  $compiler_path" | sha256sum --check --status
+          install -m 0755 "$compiler_path" "$solcx_dir/solc-v0.8.34"
       - name: Import Brownie network settings
         run: uv run brownie networks import data/networks.yml true
       - name: Compile contracts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,8 +39,6 @@ jobs:
           version: stable
       - name: Install dependencies
         run: uv sync --frozen --no-install-project
-      - name: Install Solidity compiler 0.8.23
-        run: uv run python -c "from solcx import install_solc; install_solc('0.8.23')"
       - name: Import Brownie network settings
         run: uv run brownie networks import data/networks.yml true
       - name: Compile contracts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,15 +6,15 @@ jobs:
     name: "Lint check (ruff)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
   lint-prettier:
     name: "Lint check (prettier)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Use Node.js 24
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 24
       - run: npm install
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.13"
       - name: Set up uv
@@ -47,7 +47,7 @@ jobs:
         run: uv run pytest --disable-warnings -v tests/
       - name: Generate contract JSON
         run: uv run python tools/json_filter.py
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: contract-json
           path: output

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,6 +39,8 @@ jobs:
           version: stable
       - name: Install dependencies
         run: uv sync --frozen --no-install-project
+      - name: Install Solidity compiler 0.8.23
+        run: uv run python -c "from solcx import install_solc; install_solc('0.8.23')"
       - name: Import Brownie network settings
         run: uv run brownie networks import data/networks.yml true
       - name: Compile contracts

--- a/.prettierrc
+++ b/.prettierrc
@@ -10,7 +10,7 @@
         "useTabs": false,
         "singleQuote": false,
         "bracketSpacing": false,
-        "compiler": "0.8.23"
+        "compiler": "0.8.34"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ English | [日本語](README_JA.md)
   - Version 24
 - [Solidity](https://docs.soliditylang.org/)
   - We are using Solidity to implement our smart contracts. 
-  - Currently, we are using v0.8.23.
+  - Currently, we are using v0.8.34.
 - [eth-brownie](https://github.com/eth-brownie/brownie)
   - We are using the eth-brownie framework for developing and testing our contracts.
 - [GoQuorum](https://github.com/ConsenSys/quorum)

--- a/README_JA.md
+++ b/README_JA.md
@@ -24,7 +24,7 @@
   - バージョン 24
 - [Solidity](https://docs.soliditylang.org/)
   - スマートコントラクトの実装には Solidity を利用しています。
-  - 現在、私たちは v0.8.23 を利用しています。
+  - 現在、私たちは v0.8.34 を利用しています。
 - [eth-brownie](https://github.com/eth-brownie/brownie)
   - eth-brownie フレームワークを利用して、コントラクトの開発とテストを行なっています。
 - [GoQuorum](https://github.com/ConsenSys/quorum)

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -8,6 +8,6 @@ networks:
 compiler:
     evm_version: berlin
     solc:
-        version: 0.8.23
+        version: 0.8.34
 dependencies:
     OpenZeppelin/openzeppelin-contracts@4.9.3

--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "../utils/Errors.sol";
 

--- a/contracts/exchange/DVPStorage.sol
+++ b/contracts/exchange/DVPStorage.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "../access/Ownable.sol";
 import "../utils/Errors.sol";

--- a/contracts/exchange/EscrowStorage.sol
+++ b/contracts/exchange/EscrowStorage.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "../access/Ownable.sol";
 import "../utils/Errors.sol";

--- a/contracts/exchange/ExchangeStorage.sol
+++ b/contracts/exchange/ExchangeStorage.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "../access/Ownable.sol";
 import "../utils/Errors.sol";

--- a/contracts/exchange/IbetEscrow.sol
+++ b/contracts/exchange/IbetEscrow.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "./EscrowStorage.sol";

--- a/contracts/exchange/IbetExchange.sol
+++ b/contracts/exchange/IbetExchange.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "./ExchangeStorage.sol";

--- a/contracts/exchange/IbetSecurityTokenDVP.sol
+++ b/contracts/exchange/IbetSecurityTokenDVP.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "./DVPStorage.sol";

--- a/contracts/exchange/IbetSecurityTokenEscrow.sol
+++ b/contracts/exchange/IbetSecurityTokenEscrow.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "./EscrowStorage.sol";

--- a/contracts/ledger/PersonalInfo.sol
+++ b/contracts/ledger/PersonalInfo.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "../utils/Errors.sol";
 

--- a/contracts/payment/PaymentGateway.sol
+++ b/contracts/payment/PaymentGateway.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "../access/Ownable.sol";
 import "../utils/Errors.sol";

--- a/contracts/token/IbetCoupon.sol
+++ b/contracts/token/IbetCoupon.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "../access/Ownable.sol";

--- a/contracts/token/IbetERC20.sol
+++ b/contracts/token/IbetERC20.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/token/ERC20/ERC20.sol";
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/contracts/token/IbetERC721.sol
+++ b/contracts/token/IbetERC721.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/token/ERC721/ERC721.sol";
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/token/ERC721/extensions/ERC721Burnable.sol";

--- a/contracts/token/IbetMembership.sol
+++ b/contracts/token/IbetMembership.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "../access/Ownable.sol";

--- a/contracts/token/IbetShare.sol
+++ b/contracts/token/IbetShare.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "../access/Ownable.sol";

--- a/contracts/token/IbetStandardToken.sol
+++ b/contracts/token/IbetStandardToken.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "../access/Ownable.sol";

--- a/contracts/token/IbetStraightBond.sol
+++ b/contracts/token/IbetStraightBond.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "../access/Ownable.sol";

--- a/contracts/token/TokenList.sol
+++ b/contracts/token/TokenList.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "../access/Ownable.sol";
 import "../utils/Errors.sol";

--- a/contracts/utils/ContractRegistry.sol
+++ b/contracts/utils/ContractRegistry.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "../access/Ownable.sol";
 import "../utils/Errors.sol";

--- a/contracts/utils/E2EMessaging.sol
+++ b/contracts/utils/E2EMessaging.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "./Errors.sol";
 

--- a/contracts/utils/Errors.sol
+++ b/contracts/utils/Errors.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 library ErrorCode {
     // 10XXXX

--- a/contracts/utils/FreezeLog.sol
+++ b/contracts/utils/FreezeLog.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "./Errors.sol";
 

--- a/contracts/utils/P256Wallet.sol
+++ b/contracts/utils/P256Wallet.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "./Errors.sol";
 

--- a/contracts/utils/SnapMessaging.sol
+++ b/contracts/utils/SnapMessaging.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 // @title Snap Messaging
 contract SnapMessaging {

--- a/contracts/utils/WalletTestReceiver.sol
+++ b/contracts/utils/WalletTestReceiver.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 contract WalletTestReceiver {
     uint256 public lastValue;

--- a/interfaces/ContractReceiver.sol
+++ b/interfaces/ContractReceiver.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 interface ContractReceiver {
     function tokenFallback(

--- a/interfaces/IbetExchangeInterface.sol
+++ b/interfaces/IbetExchangeInterface.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "./ContractReceiver.sol";
 

--- a/interfaces/IbetSecurityTokenInterface.sol
+++ b/interfaces/IbetSecurityTokenInterface.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "./IbetStandardTokenInterface.sol";
 

--- a/interfaces/IbetStandardTokenInterface.sol
+++ b/interfaces/IbetStandardTokenInterface.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 /// @title ibet Standard Token Interface
 abstract contract IbetStandardTokenInterface {

--- a/sandbox/ExchangeRegulatorService.sol
+++ b/sandbox/ExchangeRegulatorService.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "./Ownable.sol";
 import "../interfaces/RegulatorService.sol";

--- a/sandbox/IbetOTCExchange.sol
+++ b/sandbox/IbetOTCExchange.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 pragma experimental ABIEncoderV2;
 
 import "./SafeMath.sol";

--- a/sandbox/IbetStraightBondExchange.sol
+++ b/sandbox/IbetStraightBondExchange.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 import "./SafeMath.sol";
 import "./Ownable.sol";

--- a/sandbox/OTCExchangeStorage.sol
+++ b/sandbox/OTCExchangeStorage.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 pragma experimental ABIEncoderV2;
 
 import "./Ownable.sol";

--- a/sandbox/OTCExchangeStorageModel.sol
+++ b/sandbox/OTCExchangeStorageModel.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 /// @title OTCExchangeStorageのModel
 contract OTCExchangeStorageModel {

--- a/sandbox/RegulatorService.sol
+++ b/sandbox/RegulatorService.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.34;
 
 /// @title RegulatorServiceの標準インターフェース
 abstract contract RegulatorService {


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request upgrades the Solidity compiler version used throughout the project from `0.8.23` to `0.8.34`. It also updates related configuration files and documentation to reflect this change. 

Additionally, it pins the versions of several GitHub Actions to specific commit hashes for improved security.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Solidity Compiler Upgrade:**

* All Solidity source files in `contracts/` now specify `pragma solidity ^0.8.34;` instead of `^0.8.23;`, standardizing the compiler version across the codebase. 
* Updated the Solidity compiler version in `brownie-config.yaml` to `0.8.34`.
* Updated the `compiler` field in `.prettierrc` to `0.8.34`.

**CI/CD and Workflow Improvements:**

* Explicitly installs Solidity compiler version `0.8.34` during CI runs in `.github/workflows/pr.yml` to ensure the correct version is used.
* Updated dependencies in GitHub Actions workflows to use pinned commit SHAs for increased security and reproducibility, including `actions/checkout`, `actions/setup-node`, `actions/setup-python`, and others.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
