### PR TITLE
Pin Foundry to 1.5.1

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,8 +37,6 @@ jobs:
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
         with:
           version: "1.5.1"  # stable
-      - name: Show Forge version
-        run: forge --version
       - name: Install dependencies
         run: uv sync --frozen --no-install-project
       - name: Install Solidity compiler

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,9 +34,11 @@ jobs:
         with:
           enable-cache: true
       - name: Set up Foundry
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d  # v1.8.0
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
         with:
-          version: stable
+          version: "1.5.1"  # stable
+      - name: Show Forge version
+        run: forge --version
       - name: Install dependencies
         run: uv sync --frozen --no-install-project
       - name: Install Solidity compiler

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           enable-cache: true
       - name: Set up Foundry
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d  # v1.8.0
         with:
           version: "1.5.1"  # stable
       - name: Install dependencies


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

There appears to be a bug where specifying the `stable` version in foundry-rs/toolchain is not working correctly. Currently, specifying `stable` should use version `v1.5.1`, but it was using the latest version instead. This sometimes caused tests to get stuck (this itself seems to be a bug on the Anvil side), so I've changed it to explicitly specify version `1.5.1`.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->

None

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Replace the 'stable' toolchain reference with an explicit version (1.5.1).

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
