### PR TITLE
Add .npmrc to set release age and ignore scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=3
+ignore-scripts=true

--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,5 @@ lint:
 compile:
 	uv run ape compile
 
-test:
+test: compile
 	uv run ape test --network ethereum:local:foundry tests/ ${ARG}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,5 @@
 .PHONY: install setup update format compile test
 
-ANVIL_HOST ?= 127.0.0.1
-ANVIL_PORT ?= 8545
-ANVIL_LOG_FILE ?= /tmp/ibet-smartcontract-anvil.log
-ANVIL_STARTUP_TIMEOUT_SECONDS ?= 30
-
 install:
 	uv sync --frozen --no-install-project
 	uv run pre-commit install


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces new settings to the `.npmrc` configuration file to improve package management safety and security.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

Package management configuration:

* Added `min-release-age=3` to ensure that only packages published at least 3 days ago can be installed, reducing the risk of installing compromised or quickly-removed packages.
* Added `ignore-scripts=true` to prevent npm from running lifecycle scripts, which helps mitigate the risk of malicious code execution during install or package operations.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
